### PR TITLE
Update input_path after handler success

### DIFF
--- a/rift/agent.py
+++ b/rift/agent.py
@@ -105,16 +105,19 @@ class Agent:
         input_path = self.workspace / row['input_path']
         success, output_path, error_message = handler(input_path, step_cfg, self.workspace)
         if success:
+            new_output_path = str(output_path.relative_to(self.workspace)) if output_path else row['output_path']
+            new_input_path = str(output_path.relative_to(self.workspace)) if output_path else row['input_path']
             with self.conn:
                 next_index = step_index + 1
                 status = 'done' if next_index >= len(self.workflow) else 'pending'
                 self.conn.execute(
-                    "UPDATE instances SET step_index = ?, status = ?, updated_at = ?, output_path = ? WHERE instance_id = ?",
+                    "UPDATE instances SET step_index = ?, status = ?, updated_at = ?, output_path = ?, input_path = ? WHERE instance_id = ?",
                     (
                         next_index,
                         status,
                         datetime.datetime.utcnow().isoformat(),
-                        str(output_path.relative_to(self.workspace)) if output_path else row['output_path'],
+                        new_output_path,
+                        new_input_path,
                         instance_id,
                     ),
                 )


### PR DESCRIPTION
## Summary
- update instance `input_path` to handler output for subsequent steps
- persist new `input_path` and `output_path` together in database

## Testing
- `python -m py_compile rift/agent.py`
- `python -m py_compile rift/task_handlers/*.py`
- `python -m py_compile rift/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684032aae98083228d682d263555caca