### PR TITLE
Fix typo in laser_lens_v2 docstring

### DIFF
--- a/laser_lens/laser_lens_v2.py
+++ b/laser_lens/laser_lens_v2.py
@@ -114,7 +114,7 @@ def suggest_filename(topic: str) -> str:
 
 
 def parse_tmp(raw: str) -> Tuple[List[str], str]:
-    """Split a raw .tmp stream into finalised replies and the last incomplete chunk."""
+    """Split a raw .tmp stream into finalized replies and the last incomplete chunk."""
     chunks = [c.strip() for c in raw.split(CONFIG.delim) if c.strip()]
     return (chunks[:-1], chunks[-1]) if chunks else ([], "")
 


### PR DESCRIPTION
## Summary
- fix UK/US spelling in `parse_tmp` docstring

## Testing
- `python -m py_compile laser_lens/laser_lens_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_684031fee2488322b2fc7e428d75b828