### PR TITLE
Fix Gemini prompt parameter

### DIFF
--- a/laser_lens/recursive_agent.py
+++ b/laser_lens/recursive_agent.py
@@ -221,7 +221,7 @@ class RecursiveAgent:
         """
         try:
             stream = self.client.generate_content(
-                prompt=prompt,
+                prompt,
                 stream=True,
                 temperature=self.temperature,
                 seed=self.seed,


### PR DESCRIPTION
## Summary
- fix incorrect parameter name for `generate_content`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68412fd82f488322bc9dcc49c58555bb