### PR TITLE
Remove prompts from markdown output

### DIFF
--- a/laser_lens/cli_main.py
+++ b/laser_lens/cli_main.py
@@ -53,8 +53,7 @@ def build_markdown(history: list, topic: str) -> str:
     lines = [f"# Recursive Analysis of {topic}\n"]
     for idx, entry in enumerate(history, start=1):
         lines.append(f"## Loop {idx} ({entry['timestamp']})\n")
-        lines.append(f"**Prompt:**\n```\n{entry['prompt']}\n```\n")
-        lines.append(f"**Response:**\n```\n{entry['response']}\n```\n")
+        lines.append(f"```\n{entry['response']}\n```\n")
     return "\n".join(lines)
 
 

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -55,8 +55,7 @@ def build_markdown(history: list, topic: str) -> str:
     lines = [f"# Recursive Analysis of {topic}\n"]
     for idx, entry in enumerate(history, start=1):
         lines.append(f"## Loop {idx} ({entry['timestamp']})\n")
-        lines.append(f"**Prompt:**\n```\n{entry['prompt']}\n```\n")
-        lines.append(f"**Response:**\n```\n{entry['response']}\n```\n")
+        lines.append(f"```\n{entry['response']}\n```\n")
     return "\n".join(lines)
 
 # Initialize singletons

--- a/laser_lens/utils.py
+++ b/laser_lens/utils.py
@@ -64,8 +64,7 @@ def build_markdown(history: list, topic: str) -> str:
     lines = [f"# Recursive Analysis of {topic}\n"]
     for idx, entry in enumerate(history, start=1):
         lines.append(f"## Loop {idx} ({entry['timestamp']})\n")
-        lines.append(f"**Prompt:**\n```\n{entry['prompt']}\n```\n")
-        lines.append(f"**Response:**\n```\n{entry['response']}\n```\n")
+        lines.append(f"```\n{entry['response']}\n```\n")
     return "\n".join(lines)
 
 def load_pref_model(models_available: List[str]) -> str:


### PR DESCRIPTION
## Summary
- strip prompts from `build_markdown()` so the saved Markdown only contains loop responses

## Testing
- `python -m compileall -q`

------
https://chatgpt.com/codex/tasks/task_e_6841661593a08322be7b32f55862b0f1