### PR TITLE
Fix duplicate import and unused variable

### DIFF
--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -12,7 +12,6 @@ from agent_state import AgentState
 from recursive_agent import RecursiveAgent
 
 from utils import suggest_filename, load_pref_model, save_pref_model
-from command_executor import CommandExecutor
 from handlers import WRITE_FILE, READ_FILE, LIST_OUTPUTS, DELETE_FILE
 
 
@@ -61,7 +60,6 @@ def build_markdown(history: list, topic: str) -> str:
 # Initialize singletons
 config = Config()
 logger = ErrorLogger(config)
-command_executor = CommandExecutor(logger)
 context_manager = ContextManager(config)
 output_manager = OutputManager(config, logger)
 agent_state = AgentState(config, logger)


### PR DESCRIPTION
## Summary
- remove second `CommandExecutor` import
- drop unused `command_executor` variable and rely on `ce`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841680df6fc8322bdc736fe34179421