### PR TITLE
Fix uploaded file retrieval

### DIFF
--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -109,7 +109,9 @@ uploaded_files = st.sidebar.file_uploader(
 if uploaded_files:
     for uf in uploaded_files:
         try:
-            content = uf.read()
+            # getvalue() returns the full bytes each rerun without
+            # consuming the underlying buffer
+            content = uf.getvalue()
             context_manager.upload_context(uf.name, content)
         except Exception as e:
             logger.log("WARNING", f"Failed to upload {uf.name}", e)


### PR DESCRIPTION
## Summary
- ensure file bytes are read every rerun

## Testing
- `pytest -q`
- `ruff check` *(fails: F401, F841)*

------
https://chatgpt.com/codex/tasks/task_e_6841bec39e54832293479357564cca02