### PR TITLE
Add debug logging for uploaded context

### DIFF
--- a/laser_lens/cli_main.py
+++ b/laser_lens/cli_main.py
@@ -106,7 +106,7 @@ def main():
     config = Config()
     logger = ErrorLogger(config)
     ce = CommandExecutor(logger)
-    cm = ContextManager(config)
+    cm = ContextManager(config, logger)
     om = OutputManager(config, logger)
     as_state = AgentState(config, logger)
 

--- a/laser_lens/context_manager.py
+++ b/laser_lens/context_manager.py
@@ -1,10 +1,11 @@
 # context_manager.py
 
 import os
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 from config import Config
 from utils import count_tokens, parse_tmp
+from error_logger import ErrorLogger
 
 
 class ContextManager:
@@ -12,8 +13,9 @@ class ContextManager:
     Aggregates uploaded context files (.md, .txt) and/or a .tmp stream into a single prompt context.
     """
 
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, error_logger: Optional[ErrorLogger] = None):
         self.config = config
+        self.error_logger = error_logger
         # Internal list of (filename, content) tuples, ordered by upload time
         self._buffers: List[Tuple[str, str]] = []
 
@@ -25,6 +27,11 @@ class ContextManager:
         Otherwise, ignore.
         """
         lower = file_name.lower()
+        if self.error_logger:
+            self.error_logger.log(
+                "DEBUG",
+                f"upload_context called for {file_name} ({len(content)} bytes)"
+            )
         try:
             text = content.decode("utf-8")
         except UnicodeDecodeError:
@@ -34,15 +41,32 @@ class ContextManager:
             # parse_tmp returns (chunks, last_partial)
             chunks, _ = parse_tmp(text, self.config.default_prompt_delim)
             merged = "\n".join(chunks)
+            if self.error_logger:
+                self.error_logger.log(
+                    "DEBUG",
+                    f"parsed .tmp file {file_name}; {len(chunks)} chunks"
+                )
             self._buffers.append((file_name, merged))
         elif lower.endswith(".md") or lower.endswith(".txt"):
+            if self.error_logger:
+                self.error_logger.log(
+                    "DEBUG",
+                    f"stored text file {file_name}; {len(text)} chars"
+                )
             self._buffers.append((file_name, text))
         else:
             # Unsupported extension; ignore
+            if self.error_logger:
+                self.error_logger.log("DEBUG", f"ignored unsupported file {file_name}")
             return
 
         # Enforce max context size after adding
         self._truncate_if_needed()
+        if self.error_logger:
+            total_chars = len(self.get_context())
+            self.error_logger.log(
+                "DEBUG", f"context now has {len(self._buffers)} file(s), {total_chars} chars"
+            )
 
     def get_context(self) -> str:
         """
@@ -54,11 +78,18 @@ class ContextManager:
             parts.append(f"{delim} Context from: {fname} {delim}")
             parts.append(text)
         combined = "\n\n".join(parts).strip()
+        if self.error_logger:
+            self.error_logger.log(
+                "DEBUG",
+                f"get_context assembled {len(self._buffers)} files -> {len(combined)} chars"
+            )
         return combined
 
     def clear_context(self) -> None:
         """Remove all stored buffers."""
         self._buffers = []
+        if self.error_logger:
+            self.error_logger.log("DEBUG", "Context cleared")
 
     def _truncate_if_needed(self) -> None:
         """
@@ -69,6 +100,11 @@ class ContextManager:
             if count_tokens(combined) <= self.config.max_context_tokens:
                 break
             if self._buffers:
-                self._buffers.pop(0)
+                removed = self._buffers.pop(0)
+                if self.error_logger:
+                    self.error_logger.log(
+                        "DEBUG",
+                        f"Dropped {removed[0]} to enforce context size"
+                    )
             else:
                 break

--- a/laser_lens/recursive_agent.py
+++ b/laser_lens/recursive_agent.py
@@ -146,8 +146,13 @@ You are a “Laser Lens” recursive agent with the following capabilities:
         # 4) Include last_thought if present
         if self.last_thought:
             header += f"Your last thought:\n{self.last_thought}\n\n"
-
-        return combined + header
+        prompt = combined + header
+        if self.error_logger:
+            self.error_logger.log(
+                "DEBUG",
+                f"prompt length {len(prompt)} chars"
+            )
+        return prompt
 
     def run(self) -> Generator[Tuple[str, int, int, Any], None, None]:
         """
@@ -164,6 +169,11 @@ You are a “Laser Lens” recursive agent with the following capabilities:
 
             # Build prompt with any uploaded context
             context_str = self.context_manager.get_context()
+            if self.error_logger:
+                self.error_logger.log(
+                    "DEBUG",
+                    f"loop {self.current_loop}: context length {len(context_str)}"
+                )
             prompt = self._build_prompt(context_str)
 
             # Enforce rate limiting

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -57,7 +57,7 @@ config = Config()
 logger = ErrorLogger(config)
 # Persist ContextManager across reruns so uploaded files aren't lost
 if "context_manager" not in st.session_state:
-    st.session_state.context_manager = ContextManager(config)
+    st.session_state.context_manager = ContextManager(config, logger)
 context_manager = st.session_state.context_manager
 
 output_manager = OutputManager(config, logger)


### PR DESCRIPTION
## Summary
- add optional `ErrorLogger` to `ContextManager`
- log uploads, truncation, clears, and context assembly
- show context length when building prompt
- pass logger to `ContextManager` in CLI and UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6841cf355f508322960824c259aebc3c