### PR TITLE
Implement phase 1 reasoning core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Phase 1 - Agent Reasoning Core
+- Injected tool outputs from previous loop into the next prompt.
+- Added persistent deque-based history of last three thoughts.
+- Removed duplicate prompt builder and cleaned imports.
+


### PR DESCRIPTION
## Summary
- inject previous command results into the prompt
- keep a deque of recent agent thoughts and include it in context
- remove a duplicate prompt builder
- document progress in `CHANGELOG.md`

## Testing
- `ruff check laser_lens/recursive_agent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aad476c2c832294bb50a379e72646