### PR TITLE
Phase 2 - command framework expansion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@
 > Transform the existing research‑assistant into a local “mini‑operating‑system” agent with multi‑step reasoning, an extensible command framework, and a transparent Streamlit UI.
 > Changes are delivered in **phases** so that Copilot/Codex can apply them incrementally.
 
+> **Changelog & Documentation**
+> - After each change, append an entry to `CHANGELOG.md` summarizing the update and noting the current phase.
+> - Include clear docstrings and comments so future agents can navigate the codebase.
+> - Keep the user-facing `README.md` up to date as features are added.
+
 ---
 
 ## 📋 Prerequisites

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,8 @@
 - Added persistent deque-based history of last three thoughts.
 - Removed duplicate prompt builder and cleaned imports.
 
+## Phase 2 - Command Framework Expansion
+- Added sandboxed `EXEC` command for running shell commands in `outputs/`.
+- Created alias commands `LS`, `CAT` and `RM` via `command_registration.py`.
+- Initial README with setup and command documentation.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Laser Lens
+
+Laser Lens is a recursive research agent powered by Google's Gemini models.
+It provides both a CLI and Streamlit UI for interacting with the agent.
+
+## Setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # add your API key
+```
+
+## Usage
+
+### CLI
+
+```bash
+python -m laser_lens.cli_main --topic "Your research topic"
+```
+
+### Streamlit UI
+
+```bash
+streamlit run laser_lens/ui_main.py
+```
+
+## Available Commands
+
+| Command        | Description                               |
+| -------------- | ----------------------------------------- |
+| WRITE_FILE     | Save content to the outputs directory.    |
+| READ_FILE      | Read a file from outputs.                 |
+| LIST_OUTPUTS   | List files under outputs/.                |
+| DELETE_FILE    | Delete a file from outputs/.              |
+| EXEC           | Execute a sandboxed shell command.        |
+| LS             | Alias for `LIST_OUTPUTS`.                 |
+| CAT            | Alias for `READ_FILE`.                    |
+| RM             | Alias for `DELETE_FILE`.                  |
+

--- a/laser_lens/cli_main.py
+++ b/laser_lens/cli_main.py
@@ -7,6 +7,7 @@ import sys
 from config import Config
 from error_logger import ErrorLogger
 from command_executor import CommandExecutor
+from command_registration import register_core_commands
 from context_manager import ContextManager
 from output_manager import OutputManager
 from agent_state import AgentState
@@ -106,6 +107,7 @@ def main():
     config = Config()
     logger = ErrorLogger(config)
     ce = CommandExecutor(logger)
+    register_core_commands(ce)
     cm = ContextManager(config, logger)
     om = OutputManager(config, logger)
     as_state = AgentState(config, logger)

--- a/laser_lens/command_registration.py
+++ b/laser_lens/command_registration.py
@@ -1,0 +1,25 @@
+from command_executor import CommandExecutor
+from handlers import (
+    WRITE_FILE,
+    READ_FILE,
+    LIST_OUTPUTS,
+    DELETE_FILE,
+    EXEC,
+)
+
+
+def register_core_commands(ce: CommandExecutor) -> None:
+    """Register built-in handlers and their aliases."""
+    ce.register_command("WRITE_FILE", WRITE_FILE)
+    ce.register_command("READ_FILE", READ_FILE)
+    ce.register_command("LIST_OUTPUTS", LIST_OUTPUTS)
+    ce.register_command("DELETE_FILE", DELETE_FILE)
+    ce.register_command("EXEC", EXEC)
+
+    for alias, target in {
+        "LS": "LIST_OUTPUTS",
+        "CAT": "READ_FILE",
+        "RM": "DELETE_FILE",
+    }.items():
+        ce.register_command(alias, ce._registry[target])
+

--- a/laser_lens/context_manager.py
+++ b/laser_lens/context_manager.py
@@ -1,6 +1,5 @@
 # context_manager.py
 
-import os
 from typing import List, Tuple, Optional
 
 from config import Config

--- a/laser_lens/error_logger.py
+++ b/laser_lens/error_logger.py
@@ -53,7 +53,9 @@ class ErrorLogger:
         Note: We import Streamlit here so that CLI usage doesn't require it.
         """
         try:
-            import streamlit as st
+            import importlib
+            if importlib.util.find_spec("streamlit") is None:
+                raise ImportError
         except ImportError:
             # If Streamlit is not installed, fall back to printing the message
             print(f"[Streamlit missing] {message}", file=sys.stderr)

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -17,7 +17,7 @@ from utils import (
     save_pref_model,
     build_markdown,
 )
-from handlers import WRITE_FILE, READ_FILE, LIST_OUTPUTS, DELETE_FILE
+from command_registration import register_core_commands
 
 
 def get_available_models() -> list[str]:
@@ -61,10 +61,7 @@ agent_state = AgentState(config, logger)
 
 # Register command handlers
 ce = CommandExecutor(logger)
-ce.register_command("WRITE_FILE", WRITE_FILE)
-ce.register_command("READ_FILE", READ_FILE)
-ce.register_command("LIST_OUTPUTS", LIST_OUTPUTS)
-ce.register_command("DELETE_FILE", DELETE_FILE)
+register_core_commands(ce)
 
 st.set_page_config(page_title="Laser Lens UI", layout="wide")
 


### PR DESCRIPTION
## Summary
- require PRs to update CHANGELOG and README
- add sandboxed `EXEC` command
- introduce alias commands via `command_registration`
- use shared command registration in CLI and UI
- provide initial README for users

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685aaffb9dfc83229f45eb5e4f1b6b45