### PR TITLE
Fix ruff invocation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,6 @@ jobs:
           pip install -r requirements.txt
           pip install ruff pytest
       - name: Lint
-        run: ruff .
+        run: ruff check .
       - name: Test
         run: pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@
 > - After each change, append an entry to `CHANGELOG.md` summarizing the update and noting the current phase.
 > - Include clear docstrings and comments so future agents can navigate the codebase.
 > - Keep the user-facing `README.md` up to date as features are added.
-> - Maintain `JOURNAL.md` with notes or pain points discovered while implementing each phase. Future agents can consult this journal before starting new work.
+- Maintain `JOURNAL.md` with notes or pain points discovered while implementing each phase. Future agents can consult this journal before starting new work.
+- Agents may propose improvements or modifications to this roadmap and should update the relevant phase descriptions before implementing them.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 
 ## Phase 5 - Optional Enhancements
 - Added `JOURNAL.md` for recording development notes and pain points.
+- Updated CI workflow to run `ruff check .` and fixed missing `re` import in `cli_main.py`.

--- a/laser_lens/cli_main.py
+++ b/laser_lens/cli_main.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import re
 import sys
 
 from config import Config


### PR DESCRIPTION
## Summary
- allow agents to adjust roadmap as needed
- correct CI to run `ruff check`
- add missing `re` import in `cli_main`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abe2ca414832296200fc3efa4e4b0