### PR TITLE
Add word count command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ st.code(result, language="bash")
 * CLI parity with UI (pretty printing tool output).
 * Persist session metadata in `outputs/session.json`.
 * Plug‑in support for user‑defined commands via entry‑points.
+* Add `WORD_COUNT` command to report line and word counts.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 ## Phase 5 - Optional Enhancements
 - Added `JOURNAL.md` for recording development notes and pain points.
 - Updated CI workflow to run `ruff check .` and fixed missing `re` import in `cli_main.py`.
+- Added `WORD_COUNT` command and corresponding tests.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -5,3 +5,4 @@ This document records notes, lessons learned, and pain points discovered while w
 ## Entries
 
 - *Initial entry:* set up journal for future PRs.
+- Added WORD_COUNT command as part of optional enhancements.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ and CLI record metadata about each run in `outputs/session.json`.
 | LIST_OUTPUTS   | List files under outputs/.                |
 | DELETE_FILE    | Delete a file from outputs/.              |
 | EXEC           | Execute a sandboxed shell command.        |
+| WORD_COUNT     | Count lines and words in a file.          |
 | LS             | Alias for `LIST_OUTPUTS`.                 |
 | CAT            | Alias for `READ_FILE`.                    |
 | RM             | Alias for `DELETE_FILE`.                  |
+| WC             | Alias for `WORD_COUNT`.                   |
 | *(plugins)*    | Additional commands registered via entry points. |
 

--- a/laser_lens/command_registration.py
+++ b/laser_lens/command_registration.py
@@ -5,6 +5,7 @@ from handlers import (
     LIST_OUTPUTS,
     DELETE_FILE,
     EXEC,
+    WORD_COUNT,
 )
 
 try:
@@ -20,11 +21,13 @@ def register_core_commands(ce: CommandExecutor) -> None:
     ce.register_command("LIST_OUTPUTS", LIST_OUTPUTS)
     ce.register_command("DELETE_FILE", DELETE_FILE)
     ce.register_command("EXEC", EXEC)
+    ce.register_command("WORD_COUNT", WORD_COUNT)
 
     for alias, target in {
         "LS": "LIST_OUTPUTS",
         "CAT": "READ_FILE",
         "RM": "DELETE_FILE",
+        "WC": "WORD_COUNT",
     }.items():
         ce.register_command(alias, ce._registry[target])
 

--- a/laser_lens/handlers.py
+++ b/laser_lens/handlers.py
@@ -127,3 +127,25 @@ def EXEC(args: Dict[str, Any]) -> str:
         _logger.log("ERROR", f"Failed to EXEC '{cmd}'", e)
         return f"ERROR: Could not execute command: {e}"
 
+
+def WORD_COUNT(args: Dict[str, Any]) -> str:
+    """Return the line and word count of a file in the outputs directory."""
+    fname = args.get("filename")
+    if not fname:
+        return "ERROR: Missing required argument 'filename'."
+
+    safe_name = _output_mgr.sanitize_filename(fname)
+    path = os.path.join(os.path.expanduser(_cfg.safe_output_dir), safe_name)
+    if not os.path.isfile(path):
+        return f"ERROR: File {safe_name} does not exist."
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+        lines = len(text.splitlines())
+        words = len(text.split())
+        return f"{lines} lines, {words} words"
+    except Exception as e:  # pragma: no cover - unexpected
+        _logger.log("ERROR", f"Failed to WORD_COUNT {safe_name}", e)
+        return f"ERROR: Could not read file {safe_name}: {e}"
+

--- a/tests/test_word_count.py
+++ b/tests/test_word_count.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+from handlers import WORD_COUNT  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from config import Config  # noqa: E402
+
+
+def test_word_count(monkeypatch, tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    monkeypatch.setattr('handlers._cfg', cfg)
+    monkeypatch.setattr('handlers._output_mgr', om)
+    file_path = os.path.join(tmp_path, 'sample.txt')
+    with open(file_path, 'w', encoding='utf-8') as f:
+        f.write('hello world\nsecond line')
+    result = WORD_COUNT({'filename': 'sample.txt'})
+    assert '2 lines' in result and '4 words' in result
+
+
+def test_word_count_missing(monkeypatch, tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    monkeypatch.setattr('handlers._cfg', cfg)
+    monkeypatch.setattr('handlers._output_mgr', om)
+    result = WORD_COUNT({'filename': 'none.txt'})
+    assert 'does not exist' in result


### PR DESCRIPTION
## Summary
- add `WORD_COUNT` command implementation
- register new command and alias `WC`
- document command in `AGENTS.md` and README
- track change in `CHANGELOG.md` and JOURNAL
- test counting lines and words

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685abf1f84648322b89ae825336258f4