### PR TITLE
Add phase 7 OS-awareness features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,26 @@ string returned by `get_context()`.
 
 ---
 
+## Phase 7 – OS Awareness & Chunked Reading
+
+1. **Persist truncated uploads**
+   - When `_truncate_large_file` trims content, also save the full text to
+     `outputs/` as `full_<name>` and mention this file in the stored buffer.
+   - Provide a `READ_LINES` command so the agent can request specific line
+     ranges from these files.
+2. **HELP command & prompt update**
+   - Add a `HELP` handler returning OS details and the registered command list.
+   - Update the system prompt to explain that the agent operates inside a
+     constrained OS and may issue `[[COMMAND: HELP]]` to review capabilities.
+3. **Feedback loop**
+   - Encourage agents to record OS review notes in `outputs/feedback.md` using
+     existing write commands so future phases can improve the environment.
+
+> **Acceptance**: Agent can call `HELP` for environment info and retrieve
+lines from a saved oversize file using `READ_LINES`.
+
+---
+
 ## File‑by‑File TODO (cheat‑sheet for Copilot)
 
 | Path                  | Touch? | Key edits                 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,8 @@
 
 ## Phase 6 - Context Overflow Handling
 - Oversized context files are now truncated instead of discarded when uploaded.
+
+## Phase 7 - OS Awareness & Chunked Reading
+- Full uploads saved to `outputs/` when truncated and referenced in context.
+- Added `READ_LINES` and `HELP` commands with registration and docs.
+- Prompt now states the agent runs inside a mini OS sandbox.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -7,3 +7,4 @@ This document records notes, lessons learned, and pain points discovered while w
 - *Initial entry:* set up journal for future PRs.
 - Added WORD_COUNT command as part of optional enhancements.
 - Implemented truncation of oversize context files.
+- Began phase 7 with OS awareness, adding HELP and READ_LINES commands.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ and CLI record metadata about each run in `outputs/session.json`.
 Large uploads are truncated automatically if they would exceed the agent's
 context window. The first and last portions are kept with a `[truncated]`
 marker so oversized files still contribute useful context.
+The complete content is saved to `outputs/full_<name>` for later retrieval.
 
 ## Available Commands
 
@@ -42,6 +43,7 @@ marker so oversized files still contribute useful context.
 | -------------- | ----------------------------------------- |
 | WRITE_FILE     | Save content to the outputs directory.    |
 | READ_FILE      | Read a file from outputs.                 |
+| READ_LINES     | Read specific line range from a file.     |
 | LIST_OUTPUTS   | List files under outputs/.                |
 | DELETE_FILE    | Delete a file from outputs/.              |
 | EXEC           | Execute a sandboxed shell command.        |
@@ -50,5 +52,7 @@ marker so oversized files still contribute useful context.
 | CAT            | Alias for `READ_FILE`.                    |
 | RM             | Alias for `DELETE_FILE`.                  |
 | WC             | Alias for `WORD_COUNT`.                   |
+| RL             | Alias for `READ_LINES`.                   |
+| HELP           | Show OS info and command list.            |
 | *(plugins)*    | Additional commands registered via entry points. |
 

--- a/laser_lens/cli_main.py
+++ b/laser_lens/cli_main.py
@@ -114,8 +114,8 @@ def main():
         register_plugin_commands(ce)
     except Exception:
         pass
-    cm = ContextManager(config, logger)
     om = OutputManager(config, logger)
+    cm = ContextManager(config, logger, om)
     as_state = AgentState(config, logger)
 
     # Handle resume from .tmp if provided

--- a/laser_lens/command_registration.py
+++ b/laser_lens/command_registration.py
@@ -2,10 +2,12 @@ from command_executor import CommandExecutor
 from handlers import (
     WRITE_FILE,
     READ_FILE,
+    READ_LINES,
     LIST_OUTPUTS,
     DELETE_FILE,
     EXEC,
     WORD_COUNT,
+    HELP,
 )
 
 try:
@@ -18,16 +20,19 @@ def register_core_commands(ce: CommandExecutor) -> None:
     """Register built-in handlers and their aliases."""
     ce.register_command("WRITE_FILE", WRITE_FILE)
     ce.register_command("READ_FILE", READ_FILE)
+    ce.register_command("READ_LINES", READ_LINES)
     ce.register_command("LIST_OUTPUTS", LIST_OUTPUTS)
     ce.register_command("DELETE_FILE", DELETE_FILE)
     ce.register_command("EXEC", EXEC)
     ce.register_command("WORD_COUNT", WORD_COUNT)
+    ce.register_command("HELP", HELP)
 
     for alias, target in {
         "LS": "LIST_OUTPUTS",
         "CAT": "READ_FILE",
         "RM": "DELETE_FILE",
         "WC": "WORD_COUNT",
+        "RL": "READ_LINES",
     }.items():
         ce.register_command(alias, ce._registry[target])
 

--- a/laser_lens/handlers.py
+++ b/laser_lens/handlers.py
@@ -149,3 +149,43 @@ def WORD_COUNT(args: Dict[str, Any]) -> str:
         _logger.log("ERROR", f"Failed to WORD_COUNT {safe_name}", e)
         return f"ERROR: Could not read file {safe_name}: {e}"
 
+
+def READ_LINES(args: Dict[str, Any]) -> str:
+    """Read a specific line range from a file in outputs."""
+    fname = args.get("filename")
+    start = int(args.get("start", 1))
+    end = int(args.get("end", start + 9))
+    if not fname:
+        return "ERROR: Missing required argument 'filename'."
+
+    safe_name = _output_mgr.sanitize_filename(fname)
+    path = os.path.join(os.path.expanduser(_cfg.safe_output_dir), safe_name)
+    if not os.path.isfile(path):
+        return f"ERROR: File {safe_name} does not exist."
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            lines = f.readlines()[start - 1 : end]
+        return "".join(lines)
+    except Exception as e:
+        _logger.log("ERROR", f"Failed to READ_LINES {safe_name}", e)
+        return f"ERROR: Could not read file {safe_name}: {e}"
+
+
+def HELP(args: Dict[str, Any]) -> str:
+    """Return summary of OS environment and available commands."""
+    import platform
+
+    cmds = [
+        "WRITE_FILE",
+        "READ_FILE",
+        "READ_LINES",
+        "LIST_OUTPUTS",
+        "DELETE_FILE",
+        "EXEC",
+        "WORD_COUNT",
+        "HELP",
+    ]
+    info = platform.platform()
+    return "Available commands: " + ", ".join(cmds) + f"\nOS: {info}"
+

--- a/laser_lens/recursive_agent.py
+++ b/laser_lens/recursive_agent.py
@@ -125,8 +125,11 @@ class RecursiveAgent:
         """
         # 1) The “system” or “instruction” block:
         tool_instructions = """\
-You are a “Laser Lens” recursive agent with the following capabilities:
-  • When you embed text of the form [[COMMAND: <NAME> key="value" …]], 
+You are a “Laser Lens” recursive agent operating inside a limited OS sandbox.
+The `outputs/` directory is your writable workspace.
+You can inspect available functionality using [[COMMAND: HELP]].
+Capabilities:
+  • When you embed text of the form [[COMMAND: <NAME> key="value" …]],
     the CLI/UI will invoke a Python function named <NAME>(…) with those arguments.
     Your handler functions can perform file I/O, run shell commands, or anything
     that our CommandExecutor supports, then return a result that will be visible 

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -52,12 +52,11 @@ def get_available_models() -> list[str]:
 # Initialize singletons
 config = Config()
 logger = ErrorLogger(config)
+output_manager = OutputManager(config, logger)
 # Persist ContextManager across reruns so uploaded files aren't lost
 if "context_manager" not in st.session_state:
-    st.session_state.context_manager = ContextManager(config, logger)
+    st.session_state.context_manager = ContextManager(config, logger, output_manager)
 context_manager = st.session_state.context_manager
-
-output_manager = OutputManager(config, logger)
 agent_state = AgentState(config, logger)
 
 # Register command handlers

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -6,14 +6,18 @@ sys.path.insert(0, ROOT)
 
 from context_manager import ContextManager  # noqa: E402
 from error_logger import ErrorLogger  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
 from config import Config  # noqa: E402
 
 
 def test_oversize_file_truncated():
-    cfg = Config(max_context_tokens=120)
+    cfg = Config(max_context_tokens=120, safe_output_dir="./test_outputs")
     logger = ErrorLogger(cfg)
-    cm = ContextManager(cfg, logger)
+    om = OutputManager(cfg, logger)
+    cm = ContextManager(cfg, logger, om)
     cm.upload_context("big.txt", b"A" * 200)
     ctx = cm.get_context()
     assert "[truncated]" in ctx
     assert "Context from: big.txt" in ctx
+    files = om.list_outputs()
+    assert any("full_big.txt" in f for f in files)

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+from handlers import READ_LINES, HELP  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from config import Config  # noqa: E402
+
+
+def test_read_lines(monkeypatch, tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    monkeypatch.setattr('handlers._cfg', cfg)
+    monkeypatch.setattr('handlers._output_mgr', om)
+    file_path = os.path.join(tmp_path, "sample.txt")
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write("one\ntwo\nthree\nfour\n")
+    result = READ_LINES({"filename": "sample.txt", "start": "2", "end": "3"})
+    assert "two" in result and "three" in result
+
+
+def test_help():
+    result = HELP({})
+    assert "Available commands" in result


### PR DESCRIPTION
## Summary
- document new Phase 7 roadmap for OS awareness & chunked reading
- persist oversized uploads and save full file for agent retrieval
- add HELP and READ_LINES commands and register aliases
- update prompt to describe OS sandbox and HELP command
- update README with new commands
- adjust CLI/UI and tests for new context manager behaviour

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac67777f08322a217725298af32ff