### PR TITLE
Add command executor and context overflow tests

### DIFF
--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -1,0 +1,53 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+from command_executor import CommandExecutor  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from config import Config  # noqa: E402
+from command_registration import register_core_commands  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+
+
+def test_parse_and_execute_basic(tmp_path, monkeypatch):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    ce = CommandExecutor(logger)
+
+    def foo(args):
+        return args.get("val", "")
+
+    ce.register_command("FOO", foo)
+    results = ce.parse_and_execute("do [[COMMAND: FOO val=\"x\"]]")
+    assert results == [("FOO", "x")]
+
+
+def test_unknown_and_invalid_commands(tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    ce = CommandExecutor(logger)
+
+    results = ce.parse_and_execute("[[COMMAND: MISSING]]")
+    assert results == []
+
+    results = ce.parse_and_execute("[[COMMAND: BAD badarg]]")
+    assert results == []
+
+
+def test_alias_ls(monkeypatch, tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    ce = CommandExecutor(logger)
+    monkeypatch.setattr('handlers._cfg', cfg)
+    monkeypatch.setattr('handlers._output_mgr', om)
+    register_core_commands(ce)
+
+    om.save_output('sample.txt', 'hi')
+    results = ce.parse_and_execute('[[COMMAND: LS]]')
+    assert results
+    cmd, output = results[0]
+    assert cmd == 'LS'
+    assert 'sample.txt' in output

--- a/tests/test_context_overflow.py
+++ b/tests/test_context_overflow.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+from context_manager import ContextManager  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+from config import Config  # noqa: E402
+
+
+def test_drop_oldest_when_exceeding_limit(tmp_path):
+    cfg = Config(max_context_tokens=80, safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    cm = ContextManager(cfg, logger, om)
+
+    cm.upload_context("one.txt", b"A" * 50)
+    cm.upload_context("two.txt", b"B" * 50)
+    ctx = cm.get_context()
+    assert "two.txt" in ctx
+    assert "one.txt" not in ctx


### PR DESCRIPTION
## Summary
- add missing unit tests for `CommandExecutor`
- test dropping of oldest context when buffers exceed limit

## Testing
- `ruff check tests/test_command_executor.py tests/test_context_overflow.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ac87688748322abc1d9e7d9563a30