### PR TITLE
Improve error handling and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@
 - Full uploads saved to `outputs/` when truncated and referenced in context.
 - Added `READ_LINES` and `HELP` commands with registration and docs.
 - Prompt now states the agent runs inside a mini OS sandbox.
+- Improved `READ_LINES` error handling and added edge case tests.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -8,3 +8,6 @@ This document records notes, lessons learned, and pain points discovered while w
 - Added WORD_COUNT command as part of optional enhancements.
 - Implemented truncation of oversize context files.
 - Began phase 7 with OS awareness, adding HELP and READ_LINES commands.
+- Reviewed test coverage and added edge case tests for command parsing,
+  context uploads and output saving. Enhanced READ_LINES to validate
+  numeric ranges.

--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ The complete content is saved to `outputs/full_<name>` for later retrieval.
 | HELP           | Show OS info and command list.            |
 | *(plugins)*    | Additional commands registered via entry points. |
 
+`READ_LINES` requires numeric `start` and `end` parameters. If the values are
+non-numeric or the range is invalid the command returns an error message.
+

--- a/laser_lens/command_executor.py
+++ b/laser_lens/command_executor.py
@@ -69,6 +69,10 @@ class CommandExecutor:
             args[key] = val
         # Validate that we consumed all text
         reconstructed = " ".join(f'{k}="{v}"' for k, v in args.items())
-        if reconstructed not in raw.replace("\n", " ").strip():
+        cleaned_raw = raw.replace("\n", " ").strip()
+        if args:
+            if reconstructed not in cleaned_raw:
+                raise ValueError(f"Invalid argument format: {raw}")
+        elif cleaned_raw:
             raise ValueError(f"Invalid argument format: {raw}")
         return args

--- a/laser_lens/handlers.py
+++ b/laser_lens/handlers.py
@@ -153,10 +153,15 @@ def WORD_COUNT(args: Dict[str, Any]) -> str:
 def READ_LINES(args: Dict[str, Any]) -> str:
     """Read a specific line range from a file in outputs."""
     fname = args.get("filename")
-    start = int(args.get("start", 1))
-    end = int(args.get("end", start + 9))
+    try:
+        start = int(args.get("start", 1))
+        end = int(args.get("end", start + 9))
+    except (TypeError, ValueError):
+        return "ERROR: start and end must be integers."
     if not fname:
         return "ERROR: Missing required argument 'filename'."
+    if start <= 0 or end < start:
+        return "ERROR: Invalid line range."
 
     safe_name = _output_mgr.sanitize_filename(fname)
     path = os.path.join(os.path.expanduser(_cfg.safe_output_dir), safe_name)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,0 +1,68 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+from command_executor import CommandExecutor  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from config import Config  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+from context_manager import ContextManager  # noqa: E402
+from handlers import READ_LINES  # noqa: E402
+
+
+def test_parse_invalid_args():
+    cfg = Config()
+    logger = ErrorLogger(cfg)
+    ce = CommandExecutor(logger)
+
+    def foo(args):
+        return "ok"
+
+    ce.register_command("FOO", foo)
+    # Missing closing quote should produce no results
+    results = ce.parse_and_execute('[[COMMAND: FOO val="broken]]')
+    assert results == []
+
+
+def test_upload_unsupported_extension(tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    cm = ContextManager(cfg, logger, om)
+    cm.upload_context("notes.pdf", b"content")
+    assert cm.get_context() == ""
+
+
+def test_save_output_fallback(monkeypatch, tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+
+    real_open = open
+    call_count = {"n": 0}
+
+    def open_side_effect(path, mode="r", *args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise OSError("fail")
+        return real_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", open_side_effect)
+    path = om.save_output("file.md", "data")
+    assert os.path.isfile(path)
+    assert "output_" in os.path.basename(path)
+
+
+def test_read_lines_bad_range(monkeypatch, tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    monkeypatch.setattr("handlers._cfg", cfg)
+    monkeypatch.setattr("handlers._output_mgr", om)
+    file_path = os.path.join(tmp_path, "s.txt")
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write("one\ntwo\n")
+    result = READ_LINES({"filename": "s.txt", "start": "a"})
+    assert "start and end" in result


### PR DESCRIPTION
## Summary
- make `READ_LINES` validate range and input types
- improve argument parser in `CommandExecutor`
- document READ_LINES numeric parameters in README
- add edge case unit tests covering parser, uploads and fallback save
- note test additions in journal and changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac9e8506c8322a2d0f5262092e3f1