### PR TITLE
Fix Streamlit duplication and add new phase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,28 @@ lines from a saved oversize file using `READ_LINES`.
 
 ---
 
+## Phase 8 – File I/O Refinements
+
+Gemini testing revealed weaknesses when writing multi-line text and
+verifying file contents. To make the sandbox more reliable:
+
+1. **APPEND_FILE command**
+   - Provide a handler that appends text to an existing file under
+     `outputs/` without needing to `CAT` then `WRITE_FILE`.
+2. **Improve WRITE_FILE**
+   - Ensure any valid string (including newlines) is written intact.
+3. **Truncation notices**
+   - When CAT/READ_FILE output is shortened, prepend a warning describing
+     the original and truncated size.
+4. **Better error messages**
+   - Surface which argument failed validation when command parsing or
+     execution errors occur.
+
+> **Acceptance**: Agent can reliably append to files and receives clear
+warnings whenever output is truncated or parameters are invalid.
+
+---
+
 ## File‑by‑File TODO (cheat‑sheet for Copilot)
 
 | Path                  | Touch? | Key edits                 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,9 @@
 - Improved `READ_LINES` error handling and added edge case tests.
 - Added alias test for `RL`, more READ_LINES and EXEC edge case tests, and
   removed `agent_state/state.json` from version control.
+
+## Phase 8 - File I/O Refinements
+- Roadmap updated with a new phase focusing on APPEND_FILE and more robust
+  WRITE_FILE behaviour.
+- Fixed Streamlit UI bug that caused duplicate text to appear during
+  streaming output.


### PR DESCRIPTION
## Summary
- add Phase 8 "File I/O Refinements" to AGENTS.md
- note new phase and UI bug fix in CHANGELOG
- update `run_stream` in `ui_main.py` to use a placeholder and avoid duplicate text

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685adb7a390c8322add24e42f391772a