### PR TITLE
Implement Phase 8 file I/O improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 ## Phase 8 - File I/O Refinements
 - Roadmap updated with a new phase focusing on APPEND_FILE and more robust
   WRITE_FILE behaviour.
+- Added `APPEND_FILE` command and truncation warnings in `READ_FILE`.
+- CommandExecutor now returns explicit errors for bad arguments.
 - Fixed Streamlit UI bug that caused duplicate text to appear during
   streaming output.
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,15 @@ Large uploads are truncated automatically if they would exceed the agent's
 context window. The first and last portions are kept with a `[truncated]`
 marker so oversized files still contribute useful context.
 The complete content is saved to `outputs/full_<name>` for later retrieval.
+When `READ_FILE` truncates output to the first 10 lines it will prefix a
+`WARNING:` message showing the original line count.
 
 ## Available Commands
 
 | Command        | Description                               |
 | -------------- | ----------------------------------------- |
 | WRITE_FILE     | Save content to the outputs directory.    |
+| APPEND_FILE    | Append text to an existing file.          |
 | READ_FILE      | Read a file from outputs.                 |
 | READ_LINES     | Read specific line range from a file.     |
 | LIST_OUTPUTS   | List files under outputs/.                |

--- a/laser_lens/command_executor.py
+++ b/laser_lens/command_executor.py
@@ -39,6 +39,7 @@ class CommandExecutor:
                 self.error_logger.log(
                     "WARNING", f"Failed to parse args for command {name}: {e}"
                 )
+                results.append((name, f"ERROR: {e}"))
                 continue
 
             if name not in self._registry:
@@ -55,6 +56,7 @@ class CommandExecutor:
                 self.error_logger.log(
                     "ERROR", f"Error executing handler for command {name}", e
                 )
+                results.append((name, f"ERROR: {e}"))
         return results
 
     def _parse_args(self, raw: str) -> Dict[str, Any]:

--- a/laser_lens/command_registration.py
+++ b/laser_lens/command_registration.py
@@ -1,6 +1,7 @@
 from command_executor import CommandExecutor
 from handlers import (
     WRITE_FILE,
+    APPEND_FILE,
     READ_FILE,
     READ_LINES,
     LIST_OUTPUTS,
@@ -19,6 +20,7 @@ except ImportError:  # pragma: no cover
 def register_core_commands(ce: CommandExecutor) -> None:
     """Register built-in handlers and their aliases."""
     ce.register_command("WRITE_FILE", WRITE_FILE)
+    ce.register_command("APPEND_FILE", APPEND_FILE)
     ce.register_command("READ_FILE", READ_FILE)
     ce.register_command("READ_LINES", READ_LINES)
     ce.register_command("LIST_OUTPUTS", LIST_OUTPUTS)

--- a/laser_lens/output_manager.py
+++ b/laser_lens/output_manager.py
@@ -47,7 +47,7 @@ class OutputManager:
         safe_name = self.sanitize_filename(filename)
         full_path = os.path.join(self.safe_dir, safe_name)
         try:
-            with open(full_path, "w", encoding="utf-8") as f:
+            with open(full_path, "w", encoding="utf-8", newline="") as f:
                 f.write(content)
             return full_path
         except OSError as e:
@@ -60,7 +60,7 @@ class OutputManager:
             fallback_name = f"output_{int(time.time())}.md"
             fallback_path = os.path.join(self.safe_dir, fallback_name)
             try:
-                with open(fallback_path, "w", encoding="utf-8") as f:
+                with open(fallback_path, "w", encoding="utf-8", newline="") as f:
                     f.write(content)
                 return fallback_path
             except Exception as e2:

--- a/tests/test_append_file.py
+++ b/tests/test_append_file.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+from handlers import APPEND_FILE, WRITE_FILE, READ_FILE  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from config import Config  # noqa: E402
+
+
+def test_append_file_success(tmp_path, monkeypatch):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    monkeypatch.setattr('handlers._cfg', cfg)
+    monkeypatch.setattr('handlers._output_mgr', om)
+
+    WRITE_FILE({"filename": "file.txt", "content": "first\n"})
+    result = APPEND_FILE({"filename": "file.txt", "content": "second"})
+    assert "Appended" in result
+    with open(os.path.join(tmp_path, "file.txt"), "r", encoding="utf-8") as f:
+        content = f.read()
+    assert content == "first\nsecond"
+
+
+def test_append_file_missing(tmp_path, monkeypatch):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    monkeypatch.setattr('handlers._cfg', cfg)
+    monkeypatch.setattr('handlers._output_mgr', om)
+
+    result = APPEND_FILE({"filename": "nofile.txt", "content": "x"})
+    assert "does not exist" in result
+
+
+def test_read_file_truncation(tmp_path, monkeypatch):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    monkeypatch.setattr('handlers._cfg', cfg)
+    monkeypatch.setattr('handlers._output_mgr', om)
+
+    lines = "\n".join(str(i) for i in range(20))
+    WRITE_FILE({"filename": "big.txt", "content": lines})
+    result = READ_FILE({"filename": "big.txt"})
+    assert result.startswith("WARNING:")
+    assert "CONTENT_START" in result

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -33,7 +33,7 @@ def test_unknown_and_invalid_commands(tmp_path):
     assert results == []
 
     results = ce.parse_and_execute("[[COMMAND: BAD badarg]]")
-    assert results == []
+    assert results and results[0][1].startswith("ERROR:")
 
 
 def test_alias_ls(monkeypatch, tmp_path):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -23,7 +23,7 @@ def test_parse_invalid_args():
     ce.register_command("FOO", foo)
     # Missing closing quote should produce no results
     results = ce.parse_and_execute('[[COMMAND: FOO val="broken]]')
-    assert results == []
+    assert results and results[0][1].startswith("ERROR:")
 
 
 def test_upload_unsupported_extension(tmp_path):


### PR DESCRIPTION
## Summary
- add `APPEND_FILE` command and register it
- warn when `READ_FILE` truncates long files
- return error messages for invalid command arguments
- preserve newline characters when writing files
- document new command and behaviour in README
- update CHANGELOG and tests for new features

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685adfdad3ac8322a1bfd994dfd4e548