### PR TITLE
Implement numbered tool outputs and batch I/O test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,5 @@
 - Added new phase describing truncation warnings, detailed errors and `dry_run` options.
 - Updated AGENTS.md with timestamp syncing and PR scoping guideline.
 - Fixed Streamlit warning about duplicated `model_name` widget defaults.
+- Added numbering to tool output summaries and DEBUG logs of command sequence.
+- New test ensures multiple file commands on the same file succeed when executed in a single prompt.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -13,3 +13,4 @@ This document records notes, lessons learned, and pain points discovered while w
   numeric ranges.
 - Added tests for RL alias and additional READ_LINES/EXEC edge cases.
   Removed lingering state.json from version control.
+- Verified batch prompt with multiple file commands and added numbering for command logs.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ marker so oversized files still contribute useful context.
 The complete content is saved to `outputs/full_<name>` for later retrieval.
 When `READ_FILE` truncates output to the first 10 lines it will prefix a
 `WARNING:` message showing the original line count.
+Command outputs are numbered in prompts and logs so multi-command errors are easier to trace.
 
 ## Available Commands
 

--- a/laser_lens/command_executor.py
+++ b/laser_lens/command_executor.py
@@ -30,14 +30,15 @@ class CommandExecutor:
         For each, parse arguments, look up handler, execute, and collect (command_name, result).
         """
         results: List[Tuple[str, Any]] = []
-        for match in self.COMMAND_PATTERN.finditer(text):
+        for idx, match in enumerate(self.COMMAND_PATTERN.finditer(text), start=1):
             name = match.group("name").strip().upper()
             raw_args = match.group("args").strip()
+            self.error_logger.log("DEBUG", f"cmd {idx}: {name} {raw_args}")
             try:
                 args = self._parse_args(raw_args)
             except ValueError as e:
                 self.error_logger.log(
-                    "WARNING", f"Failed to parse args for command {name}: {e}"
+                    "WARNING", f"Failed to parse args for command {idx} {name}: {e}"
                 )
                 results.append((name, f"ERROR: {e}"))
                 continue
@@ -54,7 +55,7 @@ class CommandExecutor:
                 results.append((name, result))
             except Exception as e:
                 self.error_logger.log(
-                    "ERROR", f"Error executing handler for command {name}", e
+                    "ERROR", f"Command {idx} {name} failed", e
                 )
                 results.append((name, f"ERROR: {e}"))
         return results

--- a/laser_lens/recursive_agent.py
+++ b/laser_lens/recursive_agent.py
@@ -175,10 +175,11 @@ Capabilities:
         # Include tool outputs from previous loop
         results = self.agent_state.get_state("command_results") or []
         if results:
-            tool_context = "\n".join(
-                f"\u2022 {name}: {str(result)[:500]}" for name, result in results
-            )
-            prompt_parts.append(f"\n\n## Tool Outputs\n{tool_context}")
+            tool_lines = []
+            for idx, (name, result) in enumerate(results, start=1):
+                snippet = str(result)[:500]
+                tool_lines.append(f"\u2022 {idx}. {name}: {snippet}")
+            prompt_parts.append("\n\n## Tool Outputs\n" + "\n".join(tool_lines))
 
         prompt = "".join(prompt_parts)
         if self.error_logger:

--- a/tests/test_batch_prompt.py
+++ b/tests/test_batch_prompt.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+from command_executor import CommandExecutor  # noqa: E402
+from command_registration import register_core_commands  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from config import Config  # noqa: E402
+
+
+def test_multiple_io_in_single_prompt(tmp_path, monkeypatch):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    ce = CommandExecutor(logger)
+    monkeypatch.setattr("handlers._cfg", cfg)
+    monkeypatch.setattr("handlers._output_mgr", om)
+    register_core_commands(ce)
+
+    text = (
+        '[[COMMAND: WRITE_FILE filename="batch.txt" content="hello"]]'
+        '[[COMMAND: APPEND_FILE filename="batch.txt" content=" world"]]'
+        '[[COMMAND: READ_FILE filename="batch.txt"]]'
+    )
+    results = ce.parse_and_execute(text)
+    assert len(results) == 3
+    assert "Appended" in results[1][1]
+    assert "hello world" in results[2][1]


### PR DESCRIPTION
## Summary
- number tool outputs in prompts
- log command index in `CommandExecutor`
- test multiple file ops in a single prompt
- update docs and changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ae25fa630832293c05e73c47bfb43