### PR TITLE
Fix Unicode emoji encoding in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,4 @@
 - Ready for Gemini testing review and new feature requests.
 - Added `CANCEL` and `PAUSE` commands requiring a reason and updated UI with
   collapsible loop expanders, copy buttons, and a sidebar message box.
+- Fixed Unicode surrogate pair in copy button to avoid encoding error (phase 9).

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -348,8 +348,10 @@ def run_stream():
                 if pos < len(full_text) and text_placeholder:
                     text_placeholder.markdown(full_text[pos:])
                 copy_id = f"copy_{loop_idx}"
+                # Use full Unicode codepoint to avoid UTF-8 surrogate errors
+                # encountered when the button was defined with surrogate pairs.
                 loop_container.markdown(
-                    f"<button id='{copy_id}'>\uD83D\uDCCB Copy</button>",
+                    f"<button id='{copy_id}'>📋 Copy</button>",
                     unsafe_allow_html=True,
                 )
                 safe = json.dumps(full_text)


### PR DESCRIPTION
## Summary
- replace surrogate pair with full clipboard emoji
- document fix in CHANGELOG

## Testing
- `ruff check laser_lens/ui_main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685af1e26728832282b552817aa2a058