### PR TITLE
Fix loop rendering in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,5 @@
 - Fixed Unicode surrogate pair in copy button to avoid encoding error (phase 9).
 - Improved retry logic to wait 10 seconds on 503 "model overloaded" errors
   (phase 9) and marked phase 10 as complete in AGENTS.md.
+- Fixed blank output after loops by rendering final text in a dedicated container
+  and guarded sidebar message reset to avoid session state errors.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ their results in separate code sections. The view automatically scrolls to the
 newest output and offers a download button for the final Markdown. Both the UI
 and CLI record metadata about each run in `outputs/session.json`.
 
+When paused—via the sidebar button or a `PAUSE` command—the sidebar displays a
+message box so you can send short notes to the agent. The agent must include a
+`reason` whenever issuing `PAUSE` or `CANCEL`.
+
 Large uploads are truncated automatically if they would exceed the agent's
 context window. The first and last portions are kept with a `[truncated]`
 marker so oversized files still contribute useful context.


### PR DESCRIPTION
## Summary
- preserve final loop text by rendering command sections in a new container
- avoid session state errors when clearing pause message
- document pause behaviour in README
- record bug fix in CHANGELOG

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685afa5a36508322887ea4f8862b1787