### PR TITLE
Improve sidebar status and button layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,5 @@
   (phase 9) and marked phase 10 as complete in AGENTS.md.
 - Fixed blank output after loops by rendering final text in a dedicated container
   and guarded sidebar message reset to avoid session state errors.
+- Sidebar now shows agent status, Start/Pause/Resume/Stop buttons are horizontal,
+  and blank loop expanders no longer appear (phase 10).

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ streamlit run laser_lens/ui_main.py
 
 During each loop the UI highlights commands as informational blocks and shows
 their results in separate code sections. The view automatically scrolls to the
-newest output and offers a download button for the final Markdown. Both the UI
-and CLI record metadata about each run in `outputs/session.json`.
+newest output and offers a download button for the final Markdown. The sidebar
+displays the current agent status and presents the Start/Pause/Resume/Stop
+controls in a single row. Both the UI and CLI record metadata about each run in
+`outputs/session.json`.
 
 When paused—via the sidebar button or a `PAUSE` command—the sidebar displays a
 message box so you can send short notes to the agent. The agent must include a


### PR DESCRIPTION
## Summary
- arrange Start/Pause/Resume/Stop buttons horizontally
- clear pause message safely and show current agent status
- avoid blank loop containers by creating the next loop on-demand
- document UI tweaks in README
- note UI updates in CHANGELOG

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b2a6d66f0832294cda45bf4aa33cd