### PR TITLE
Update start button and icon controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,4 @@
   and guarded sidebar message reset to avoid session state errors.
 - Sidebar now shows agent status, Start/Pause/Resume/Stop buttons are horizontal,
   and blank loop expanders no longer appear (phase 10).
+- Start button now submits settings form automatically and all control buttons use icons only.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -14,3 +14,4 @@ This document records notes, lessons learned, and pain points discovered while w
 - Added tests for RL alias and additional READ_LINES/EXEC edge cases.
   Removed lingering state.json from version control.
 - Verified batch prompt with multiple file commands and added numbering for command logs.
+- Moved Start button into settings form and converted control buttons to icons.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ streamlit run laser_lens/ui_main.py
 During each loop the UI highlights commands as informational blocks and shows
 their results in separate code sections. The view automatically scrolls to the
 newest output and offers a download button for the final Markdown. The sidebar
-displays the current agent status and presents the Start/Pause/Resume/Stop
-controls in a single row. Both the UI and CLI record metadata about each run in
-`outputs/session.json`.
+displays the current agent status. The Start button now lives inside the
+settings form so any changes are applied automatically, while the
+Pause/Resume/Stop controls appear in a single row using icon-only buttons.
+Both the UI and CLI record metadata about each run in `outputs/session.json`.
 
 When paused—via the sidebar button or a `PAUSE` command—the sidebar displays a
 message box so you can send short notes to the agent. The agent must include a

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -136,28 +136,35 @@ if uploaded_files:
 st.sidebar.markdown("---")
 with st.sidebar.form("agent_settings"):
     st.header("Agent Settings")
-    topic_in = st.text_input("Topic", value=st.session_state.topic)
+    topic_in = st.text_input("Topic", value=st.session_state.topic, key="topic_in")
     loops_in = st.slider(
-        "Recursion Loops", min_value=1, max_value=500, value=st.session_state.loops
+        "Recursion Loops", min_value=1, max_value=500, value=st.session_state.loops, key="loops_in"
     )
     st.selectbox(
         "Model",
         models_available,
         key="model_name",
     )
-    temp_in = st.slider("Temperature", 0.0, 1.0, value=st.session_state.temperature)
+    temp_in = st.slider(
+        "Temperature", 0.0, 1.0, value=st.session_state.temperature, key="temp_in"
+    )
     seed_in = st.number_input(
         "Seed (optional)",
         min_value=0,
         max_value=2**32 - 1,
         value=st.session_state.seed,
+        key="seed_in",
     )
     rpm_in = st.number_input(
-        "Requests/minute", min_value=1, max_value=100, value=st.session_state.rpm
+        "Requests/minute", min_value=1, max_value=100, value=st.session_state.rpm, key="rpm_in"
     )
-    apply_btn = st.form_submit_button("Apply")
+    btn_cols = st.columns(2)
+    with btn_cols[0]:
+        apply_btn = st.form_submit_button("Apply")
+    with btn_cols[1]:
+        start_btn = st.form_submit_button("▶️", help="Start")
 
-if apply_btn:
+if apply_btn or start_btn:
     st.session_state.topic = topic_in
     st.session_state.loops = loops_in
     st.session_state.temperature = temp_in
@@ -175,15 +182,13 @@ else:
 # Sidebar: Control Buttons
 st.sidebar.markdown("---")
 action_reason = st.sidebar.text_input("Reason", key="action_reason")
-btn_cols = st.sidebar.columns(4)
+btn_cols = st.sidebar.columns(3)
 with btn_cols[0]:
-    start_btn = st.button("▶️ Start")
+    pause_btn = st.button("⏸️", help="Pause")
 with btn_cols[1]:
-    pause_btn = st.button("⏸️ Pause")
+    resume_btn = st.button("▶️", help="Resume")
 with btn_cols[2]:
-    resume_btn = st.button("▶️ Resume")
-with btn_cols[3]:
-    stop_btn = st.button("⏹️ Stop")
+    stop_btn = st.button("⏹️", help="Stop")
 
 # Message box (enabled when paused)
 if st.session_state.reset_pause_msg:


### PR DESCRIPTION
## Summary
- ensure Start applies sidebar settings
- show Start button inside the settings form
- use icons with hover text for Pause/Resume/Stop
- document UI change in README and CHANGELOG
- note design update in JOURNAL

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b2daee5588322bed42024d86ce3f0