### PR TITLE
Fix loop counter and UI idle state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,4 @@
 - Sidebar now shows agent status, Start/Pause/Resume/Stop buttons are horizontal,
   and blank loop expanders no longer appear (phase 10).
 - Start button now submits settings form automatically and all control buttons use icons only.
+* Fixed loop counter persisting one beyond final loop and reset UI status on completion (phase 10).

--- a/laser_lens/recursive_agent.py
+++ b/laser_lens/recursive_agent.py
@@ -292,6 +292,11 @@ Capabilities:
             if self.paused:
                 break
 
+        # If recursion completed normally, cap current_loop at total_loops so
+        # the UI does not show an impossible "loop N+1 of N" status.
+        if not self.paused and not self.cancelled and self.current_loop > total_loops:
+            self.current_loop = total_loops
+            self.agent_state.update_state("current_loop", self.current_loop)
 
         self.agent_state.save_state()
 

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -466,6 +466,8 @@ def run_stream():
             "output_file": saved,
         }
         output_manager.save_session_metadata(session_meta)
+        # Mark run as complete so sidebar status shows "Idle"
+        st.session_state.agent = None
     except Exception as e:
         logger.log("ERROR", "Failed to save final Markdown in UI", e)
         logger.display_interactive(


### PR DESCRIPTION
## Summary
- ensure current_loop is capped at total_loops when recursion completes
- mark agent as None after saving final output so sidebar shows idle
- document the fix in CHANGELOG

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b345f317c832287739814f2388e4c