### PR TITLE
Handle quota limit errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,3 +64,4 @@
   and blank loop expanders no longer appear (phase 10).
 - Start button now submits settings form automatically and all control buttons use icons only.
 * Fixed loop counter persisting one beyond final loop and reset UI status on completion (phase 10).
+* Quota limit errors now abort execution immediately with a concise message (phase 9).

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The complete content is saved to `outputs/full_<name>` for later retrieval.
 When `READ_FILE` truncates output to the first 10 lines it will prefix a
 `WARNING:` message showing the original line count.
 Command outputs are numbered in prompts and logs so multi-command errors are easier to trace.
+Severe API errors appear as concise messages. If a quota limit is hit the agent stops immediately without retrying.
 
 ## Available Commands
 

--- a/tests/test_quota_error.py
+++ b/tests/test_quota_error.py
@@ -1,0 +1,72 @@
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+# Provide dummy google modules so recursive_agent can be imported
+google = types.ModuleType("google")
+generativeai = types.ModuleType("generativeai")
+class DummyModel:
+    def __init__(self, *a, **k):
+        pass
+
+generativeai.GenerativeModel = DummyModel
+
+api_core = types.ModuleType("api_core")
+exc_mod = types.ModuleType("exceptions")
+class QuotaError(Exception):
+    pass
+exc_mod.ResourceExhausted = QuotaError
+api_core.exceptions = exc_mod
+
+google.generativeai = generativeai
+google.api_core = api_core
+sys.modules.setdefault("google", google)
+sys.modules.setdefault("google.generativeai", generativeai)
+sys.modules.setdefault("google.api_core", api_core)
+sys.modules.setdefault("google.api_core.exceptions", exc_mod)
+
+from recursive_agent import RecursiveAgent  # noqa: E402
+from command_executor import CommandExecutor  # noqa: E402
+from context_manager import ContextManager  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+from agent_state import AgentState  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from config import Config  # noqa: E402
+
+
+def test_quota_error_aborts(monkeypatch, tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    cm = ContextManager(cfg, logger, om)
+    ce = CommandExecutor(logger)
+    state = AgentState(cfg, logger)
+
+    agent = RecursiveAgent(
+        config=cfg,
+        error_logger=logger,
+        command_executor=ce,
+        context_manager=cm,
+        output_manager=om,
+        agent_state=state,
+        model_name="dummy",
+        topic="t",
+        loops=1,
+        temperature=0.0,
+        seed=None,
+        rpm=10,
+        api_key="x",
+    )
+
+    monkeypatch.setattr(
+        agent,
+        "_stream_generation",
+        lambda prompt: (_ for _ in ()).throw(QuotaError("quota exceeded")),
+    )
+
+    events = list(agent.run())
+    assert events and events[0][0] == "error"
+    assert "quota" in events[0][3][0].lower()


### PR DESCRIPTION
## Summary
- gracefully abort recursion when API quota is exhausted
- surface concise quota messages to the user
- document behaviour in README and changelog
- test quota error handling logic

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b37bfb0fc8322a374123d9d452dff