### PR TITLE
Implement dry run and warnings (phase 9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Last feedback synced: 2025-06-25 01:06 UTC
 | 10 – Pause Messaging & UI Improvements | ✅ Completed |
 | 11 – Extended HELP & Python Sandbox | ☐ Proposed |
 | 12 – Resume Rendering Fix | ☐ Proposed |
+| 13 – Documentation Overhaul | ☐ Proposed |
 
 ---
 
@@ -269,6 +270,21 @@ prior logs.
      restarting the scroll at the beginning.
 
 > **Acceptance**: Output picks up seamlessly after resuming.
+
+---
+
+## Phase 13 – Documentation Overhaul
+
+Consolidate existing documentation into a formal docs site.
+
+1. **Sphinx site**
+   - Generate API documentation from docstrings under a new `docs/` folder.
+   - Provide a short Makefile or script so `make html` builds the docs.
+2. **Content reorganisation**
+   - Move extended command descriptions out of `README.md` into the docs.
+   - Link to generated docs from the README and UI footer.
+
+> **Acceptance**: `make html` builds without warnings and README links to `/docs`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,4 @@
 - Start button now submits settings form automatically and all control buttons use icons only.
 * Fixed loop counter persisting one beyond final loop and reset UI status on completion (phase 10).
 * Quota limit errors now abort execution immediately with a concise message (phase 9).
+* Added dry-run support for EXEC and WRITE_FILE, improved parse errors, and context warnings now include sizes (phase 9).

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Severe API errors appear as concise messages. If a quota limit is hit the agent 
 
 | Command        | Description                               |
 | -------------- | ----------------------------------------- |
-| WRITE_FILE     | Save content to the outputs directory.    |
+| WRITE_FILE     | Save content to the outputs directory. Use `dry_run=true` to preview. |
 | APPEND_FILE    | Append text to an existing file.          |
 | READ_FILE      | Read a file from outputs.                 |
 | READ_LINES     | Read specific line range from a file.     |
 | LIST_OUTPUTS   | List files under outputs/.                |
 | DELETE_FILE    | Delete a file from outputs/.              |
-| EXEC           | Execute a sandboxed shell command.        |
+| EXEC           | Execute a sandboxed shell command. Use `dry_run=true` to preview. |
 | WORD_COUNT     | Count lines and words in a file.          |
 | LS             | Alias for `LIST_OUTPUTS`.                 |
 | CAT            | Alias for `READ_FILE`.                    |
@@ -72,4 +72,7 @@ Severe API errors appear as concise messages. If a quota limit is hit the agent 
 
 `READ_LINES` requires numeric `start` and `end` parameters. If the values are
 non-numeric or the range is invalid the command returns an error message.
+
+Both `WRITE_FILE` and `EXEC` accept a boolean `dry_run` parameter to preview the
+operation without making changes.
 

--- a/laser_lens/command_executor.py
+++ b/laser_lens/command_executor.py
@@ -70,12 +70,9 @@ class CommandExecutor:
         pair_pattern = re.compile(r'(\w+)\s*=\s*"(.*?)"', re.DOTALL)
         for key, val in pair_pattern.findall(raw):
             args[key] = val
-        # Validate that we consumed all text
-        reconstructed = " ".join(f'{k}="{v}"' for k, v in args.items())
         cleaned_raw = raw.replace("\n", " ").strip()
-        if args:
-            if reconstructed not in cleaned_raw:
-                raise ValueError(f"Invalid argument format: {raw}")
-        elif cleaned_raw:
-            raise ValueError(f"Invalid argument format: {raw}")
+        leftover = pair_pattern.sub("", cleaned_raw).strip()
+        if leftover:
+            token = leftover.split()[0]
+            raise ValueError(f"Invalid argument {token}")
         return args

--- a/laser_lens/context_manager.py
+++ b/laser_lens/context_manager.py
@@ -37,15 +37,17 @@ class ContextManager:
         marker = "\n...[truncated]...\n"
         keep = max(0, (limit - len(marker)) // 2)
         truncated = text[:keep] + marker + text[-keep:]
+        orig_len = len(text)
         if self.output_manager:
             safe_name = self.output_manager.sanitize_filename(f"full_{file_name}")
             self.output_manager.save_output(safe_name, text)
             truncated += f"\n\n[Full file saved as {safe_name}]"
+        warning = f"WARNING: truncated from {orig_len} chars to {len(truncated)} chars\n"
         if self.error_logger:
             self.error_logger.log(
                 "INFO", f"Truncated {file_name} to fit context window"
             )
-        return truncated
+        return warning + truncated
 
     def upload_context(self, file_name: str, content: bytes) -> None:
         """

--- a/laser_lens/handlers.py
+++ b/laser_lens/handlers.py
@@ -24,8 +24,13 @@ def WRITE_FILE(args: Dict[str, Any]) -> str:
     """
     fname = args.get("filename")
     content = args.get("content", "")
+    dry = str(args.get("dry_run", "false")).lower() == "true"
     if not fname:
         return "ERROR: Missing required argument 'filename'."
+
+    if dry:
+        safe = _output_mgr.sanitize_filename(fname)
+        return f"DRY RUN: would write {len(content)} chars to {safe}"
 
     try:
         saved_path = _output_mgr.save_output(fname, content)
@@ -129,12 +134,16 @@ def DELETE_FILE(args: Dict[str, Any]) -> str:
 def EXEC(args: Dict[str, Any]) -> str:
     """Execute a shell command within the outputs sandbox."""
     cmd = args.get("cmd")
+    dry = str(args.get("dry_run", "false")).lower() == "true"
     if not cmd:
         return "ERROR: Missing required argument 'cmd'."
 
     banned = ["sudo", "rm -rf", "curl", "wget", "ssh"]
     if any(b in cmd for b in banned):
         return "ERROR: Command contains prohibited patterns."
+
+    if dry:
+        return f"DRY RUN: would execute '{cmd}'"
 
     try:
         proc = subprocess.run(

--- a/tests/test_append_file.py
+++ b/tests/test_append_file.py
@@ -36,6 +36,18 @@ def test_append_file_missing(tmp_path, monkeypatch):
     assert "does not exist" in result
 
 
+def test_write_file_dry_run(tmp_path, monkeypatch):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    monkeypatch.setattr('handlers._cfg', cfg)
+    monkeypatch.setattr('handlers._output_mgr', om)
+
+    result = WRITE_FILE({"filename": "x.txt", "content": "hi", "dry_run": "true"})
+    assert "DRY RUN" in result
+    assert not os.path.exists(os.path.join(tmp_path, "x.txt"))
+
+
 def test_read_file_truncation(tmp_path, monkeypatch):
     cfg = Config(safe_output_dir=str(tmp_path))
     logger = ErrorLogger(cfg)

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -33,7 +33,7 @@ def test_unknown_and_invalid_commands(tmp_path):
     assert results == []
 
     results = ce.parse_and_execute("[[COMMAND: BAD badarg]]")
-    assert results and results[0][1].startswith("ERROR:")
+    assert results and "badarg" in results[0][1]
 
 
 def test_alias_ls(monkeypatch, tmp_path):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -17,6 +17,7 @@ def test_oversize_file_truncated():
     cm = ContextManager(cfg, logger, om)
     cm.upload_context("big.txt", b"A" * 200)
     ctx = cm.get_context()
+    assert "WARNING:" in ctx
     assert "[truncated]" in ctx
     assert "Context from: big.txt" in ctx
     files = om.list_outputs()

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -27,3 +27,12 @@ def test_exec_success(monkeypatch):
     monkeypatch.setattr(subprocess, "run", fake_run)
     result = EXEC({"cmd": "echo ok"})
     assert result == "ok"
+
+
+def test_exec_dry_run(monkeypatch):
+    def fail_run(*args, **kwargs):
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(subprocess, "run", fail_run)
+    result = EXEC({"cmd": "echo hi", "dry_run": "true"})
+    assert "DRY RUN" in result


### PR DESCRIPTION
## Summary
- add dry_run option to WRITE_FILE and EXEC
- emit size warnings for truncated context files
- improve argument parse errors
- document new parameters and add roadmap phase 13
- tests cover dry run, warnings, and error messages

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4eef32a4832281a12b287ca64143