### PR TITLE
Implement Phase 11 - Python sandbox and HELP update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Last feedback synced: 2025-06-25 01:06 UTC
 | 8 – File I/O Refinements | ✅ Completed |
 | 9 – Transparency & Dry Run | ☐ In Progress |
 | 10 – Pause Messaging & UI Improvements | ✅ Completed |
-| 11 – Extended HELP & Python Sandbox | ☐ Proposed |
+| 11 – Extended HELP & Python Sandbox | ✅ Completed |
 | 12 – Resume Rendering Fix | ☐ Proposed |
 | 13 – Documentation Overhaul | ☐ Proposed |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,9 @@
 * Fixed loop counter persisting one beyond final loop and reset UI status on completion (phase 10).
 * Quota limit errors now abort execution immediately with a concise message (phase 9).
 * Added dry-run support for EXEC and WRITE_FILE, improved parse errors, and context warnings now include sizes (phase 9).
+
+## Phase 11 - Extended HELP & Python Sandbox
+- HELP now lists each command with its arguments and a short description.
+- Added RUN_PYTHON command to execute Python snippets in the outputs sandbox.
+- Documented virtual environment setup in README.
+- Tests cover RUN_PYTHON and updated HELP output.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -15,3 +15,4 @@ This document records notes, lessons learned, and pain points discovered while w
   Removed lingering state.json from version control.
 - Verified batch prompt with multiple file commands and added numbering for command logs.
 - Moved Start button into settings form and converted control buttons to icons.
+- Implemented RUN_PYTHON command and expanded HELP output. Updated docs and tests accordingly.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ pip install -r requirements.txt
 cp .env.example .env  # add your API key
 ```
 
+### Python Sandbox
+
+To run `RUN_PYTHON` commands create a virtual environment and install
+the requirements:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
 ## Usage
 
 ### CLI
@@ -59,6 +69,7 @@ Severe API errors appear as concise messages. If a quota limit is hit the agent 
 | LIST_OUTPUTS   | List files under outputs/.                |
 | DELETE_FILE    | Delete a file from outputs/.              |
 | EXEC           | Execute a sandboxed shell command. Use `dry_run=true` to preview. |
+| RUN_PYTHON     | Run Python code inside the sandbox.       |
 | WORD_COUNT     | Count lines and words in a file.          |
 | LS             | Alias for `LIST_OUTPUTS`.                 |
 | CAT            | Alias for `READ_FILE`.                    |

--- a/laser_lens/command_registration.py
+++ b/laser_lens/command_registration.py
@@ -7,6 +7,7 @@ from handlers import (
     LIST_OUTPUTS,
     DELETE_FILE,
     EXEC,
+    RUN_PYTHON,
     WORD_COUNT,
     HELP,
     CANCEL,
@@ -28,6 +29,7 @@ def register_core_commands(ce: CommandExecutor) -> None:
     ce.register_command("LIST_OUTPUTS", LIST_OUTPUTS)
     ce.register_command("DELETE_FILE", DELETE_FILE)
     ce.register_command("EXEC", EXEC)
+    ce.register_command("RUN_PYTHON", RUN_PYTHON)
     ce.register_command("WORD_COUNT", WORD_COUNT)
     ce.register_command("HELP", HELP)
     ce.register_command("CANCEL", CANCEL)

--- a/tests/test_new_commands.py
+++ b/tests/test_new_commands.py
@@ -27,7 +27,7 @@ def test_read_lines(monkeypatch, tmp_path):
 
 def test_help():
     result = HELP({})
-    assert "Available commands" in result
+    assert "RUN_PYTHON" in result
 
 
 def test_rl_alias(monkeypatch, tmp_path):

--- a/tests/test_run_python.py
+++ b/tests/test_run_python.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import subprocess
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+from handlers import RUN_PYTHON  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from config import Config  # noqa: E402
+
+
+def test_run_python_success(tmp_path, monkeypatch):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    monkeypatch.setattr('handlers._cfg', cfg)
+    monkeypatch.setattr('handlers._output_mgr', om)
+
+    result = RUN_PYTHON({"code": "print('hi')"})
+    assert "hi" in result
+
+
+def test_run_python_timeout(monkeypatch):
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="python", timeout=10)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = RUN_PYTHON({"code": "print('x')"})
+    assert "timed out" in result
+
+
+def test_run_python_missing():
+    result = RUN_PYTHON({})
+    assert "Missing required" in result


### PR DESCRIPTION
## Summary
- enhance command help output and implement new `RUN_PYTHON` command
- register new command and document virtual environment setup
- add tests for `RUN_PYTHON`
- update changelog, roadmap and journal

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b62d7fffc832298e2b144e5a0c4fe