### PR TITLE
Implement Phase 12 resume scroll fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,5 @@ laser_lens/__pycache__/utils.cpython-311.pyc
 laser_lens/agent_state/state.json
 laser_lens/agent_state/state.json
 laser_lens/agent_state/state.json
+agent_state/
+test_outputs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ Last feedback synced: 2025-06-25 05:40 UTC
 | 6 – Context Overflow Handling | ✅ Completed |
 | 7 – OS Awareness & Chunked Reading | ✅ Completed |
 | 8 – File I/O Refinements | ✅ Completed |
-| 9 – Transparency & Dry Run | ☐ In Progress |
+| 9 – Transparency & Dry Run | ✅ Completed |
 | 10 – Pause Messaging & UI Improvements | ✅ Completed |
 | 11 – Extended HELP & Python Sandbox | ✅ Completed |
-| 12 – Resume Rendering Fix | ☐ Proposed |
+| 12 – Resume Rendering Fix | ✅ Completed |
 | 13 – Documentation Overhaul | ☐ Proposed |
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,3 +73,6 @@
 - Documented virtual environment setup in README.
 - Tests cover RUN_PYTHON and updated HELP output.
 - Moved GEMINIOUTPUT.md to laser_lens/outputs/ and introduced laser_lens/outputs/GEMINIINPUT.md for bidirectional notes (phase 9).
+
+## Phase 12 - Resume Rendering Fix
+- Resuming from pause now scrolls back to the latest output instead of the top.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ streamlit run laser_lens/ui_main.py
 
 During each loop the UI highlights commands as informational blocks and shows
 their results in separate code sections. The view automatically scrolls to the
-newest output and offers a download button for the final Markdown. The sidebar
+newest output and offers a download button for the final Markdown. When resuming
+from a pause the page jumps back to the latest output instead of the top. The sidebar
 displays the current agent status. The Start button now lives inside the
 settings form so any changes are applied automatically, while the
 Pause/Resume/Stop controls appear in a single row using icon-only buttons.

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -484,6 +484,11 @@ if pause_btn and st.session_state.agent:
     st.session_state.agent.request_pause(action_reason or "user pause")
 
 if resume_btn and st.session_state.agent:
+    # Scroll to the bottom so rendering continues from the last loop
+    st.markdown(
+        "<script>window.scrollTo(0, document.body.scrollHeight);</script>",
+        unsafe_allow_html=True,
+    )
     st.session_state.agent.resume()
     run_stream()
 


### PR DESCRIPTION
## Summary
- mark Phase 9 complete and Phase 12 complete in roadmap
- fix UI resume scroll behaviour
- document resume scrolling behaviour in README
- note phase completion in CHANGELOG
- ignore generated state and test outputs

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b9b3c96388322a867f25c4695f144