### PR TITLE
Implement phase 13 docs overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,3 +76,8 @@
 
 ## Phase 12 - Resume Rendering Fix
 - Resuming from pause now scrolls back to the latest output instead of the top.
+
+## Phase 13 - Documentation Overhaul
+- Added Sphinx docs under `docs/` with command reference and API modules.
+- README now links to the docs and command table was moved.
+- UI footer includes a link to `/docs`.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -16,3 +16,4 @@ This document records notes, lessons learned, and pain points discovered while w
 - Verified batch prompt with multiple file commands and added numbering for command logs.
 - Moved Start button into settings form and converted control buttons to icons.
 - Implemented RUN_PYTHON command and expanded HELP output. Updated docs and tests accordingly.
+- Began phase 13 with Sphinx docs and README cleanup.

--- a/README.md
+++ b/README.md
@@ -60,32 +60,8 @@ When `READ_FILE` truncates output to the first 10 lines it will prefix a
 Command outputs are numbered in prompts and logs so multi-command errors are easier to trace.
 Severe API errors appear as concise messages. If a quota limit is hit the agent stops immediately without retrying.
 
-## Available Commands
 
-| Command        | Description                               |
-| -------------- | ----------------------------------------- |
-| WRITE_FILE     | Save content to the outputs directory. Use `dry_run=true` to preview. |
-| APPEND_FILE    | Append text to an existing file.          |
-| READ_FILE      | Read a file from outputs.                 |
-| READ_LINES     | Read specific line range from a file.     |
-| LIST_OUTPUTS   | List files under outputs/.                |
-| DELETE_FILE    | Delete a file from outputs/.              |
-| EXEC           | Execute a sandboxed shell command. Use `dry_run=true` to preview. |
-| RUN_PYTHON     | Run Python code inside the sandbox.       |
-| WORD_COUNT     | Count lines and words in a file.          |
-| LS             | Alias for `LIST_OUTPUTS`.                 |
-| CAT            | Alias for `READ_FILE`.                    |
-| RM             | Alias for `DELETE_FILE`.                  |
-| WC             | Alias for `WORD_COUNT`.                   |
-| RL             | Alias for `READ_LINES`.                   |
-| HELP           | Show OS info and command list.            |
-| CANCEL         | Stop recursion with a reason.             |
-| PAUSE          | Pause recursion with a reason.            |
-| *(plugins)*    | Additional commands registered via entry points. |
+## Documentation
 
-`READ_LINES` requires numeric `start` and `end` parameters. If the values are
-non-numeric or the range is invalid the command returns an error message.
-
-Both `WRITE_FILE` and `EXEC` accept a boolean `dry_run` parameter to preview the
-operation without making changes.
-
+The list of available commands and API reference is maintained in the
+[project documentation](docs/index.html).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,7 @@
+SPHINXBUILD ?= sphinx-build
+SOURCEDIR = .
+BUILDDIR = _build
+
+.PHONY: html
+html:
+	$(SPHINXBUILD) -M html $(SOURCEDIR) $(BUILDDIR)

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -1,0 +1,52 @@
+Commands
+========
+
+The following commands are available to the agent:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Command
+     - Description
+   * - WRITE_FILE
+     - Save content to the outputs directory. Use ``dry_run=true`` to preview.
+   * - APPEND_FILE
+     - Append text to an existing file.
+   * - READ_FILE
+     - Read a file from outputs.
+   * - READ_LINES
+     - Read specific line range from a file.
+   * - LIST_OUTPUTS
+     - List files under outputs/.
+   * - DELETE_FILE
+     - Delete a file from outputs/.
+   * - EXEC
+     - Execute a sandboxed shell command. Use ``dry_run=true`` to preview.
+   * - RUN_PYTHON
+     - Run Python code inside the sandbox.
+   * - WORD_COUNT
+     - Count lines and words in a file.
+   * - LS
+     - Alias for ``LIST_OUTPUTS``.
+   * - CAT
+     - Alias for ``READ_FILE``.
+   * - RM
+     - Alias for ``DELETE_FILE``.
+   * - WC
+     - Alias for ``WORD_COUNT``.
+   * - RL
+     - Alias for ``READ_LINES``.
+   * - HELP
+     - Show OS info and command list.
+   * - CANCEL
+     - Stop recursion with a reason.
+   * - PAUSE
+     - Pause recursion with a reason.
+   * - *(plugins)*
+     - Additional commands registered via entry points.
+
+``READ_LINES`` requires numeric ``start`` and ``end`` parameters. If the values
+are non-numeric or the range is invalid the command returns an error message.
+
+Both ``WRITE_FILE`` and ``EXEC`` accept a boolean ``dry_run`` parameter to
+preview the operation without making changes.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,8 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'Laser Lens'
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary']
+autosummary_generate = True
+html_theme = 'alabaster'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,9 @@
+Laser Lens Documentation
+========================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   commands
+   modules

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,15 @@
+API Reference
+=============
+
+.. autosummary::
+   :toctree: generated
+   :recursive:
+
+   laser_lens.command_executor
+   laser_lens.handlers
+   laser_lens.context_manager
+   laser_lens.output_manager
+   laser_lens.recursive_agent
+   laser_lens.command_registration
+   laser_lens.ui_main
+   laser_lens.cli_main

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -494,3 +494,6 @@ if resume_btn and st.session_state.agent:
 
 if stop_btn and st.session_state.agent:
     st.session_state.agent.request_cancel(action_reason or "user cancel")
+
+# Documentation Link
+st.markdown("[📖 Documentation](/docs/index.html)")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 openai
 google-generativeai
 python-dotenv
+sphinx


### PR DESCRIPTION
## Summary
- add Sphinx configuration and docs folder
- move command table from README into docs
- link to docs from README and UI footer
- update changelog and journal
- add sphinx to requirements

## Testing
- `ruff check .`
- `pytest -q`
- `make -C docs html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9c7c931c8322b70b5d9f7c2bf799