### PR TITLE
Implement Phase 14 - improved EXEC quoting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Last feedback synced: 2025-06-25 07:32 UTC
 | 11 – Extended HELP & Python Sandbox | ✅ Completed |
 | 12 – Resume Rendering Fix | ✅ Completed |
 | 13 – Documentation Overhaul | ✅ Completed |
+| 14 – Improved EXEC Quoting | 🚧 In Progress |
 
 ---
 
@@ -285,6 +286,24 @@ Consolidate existing documentation into a formal docs site.
    - Link to generated docs from the README and UI footer.
 
 > **Acceptance**: `make html` builds without warnings and README links to `/docs`.
+
+---
+
+## Phase 14 – Improved EXEC Quoting
+
+Gemini feedback highlighted quoting problems when running ``EXEC`` commands on
+Windows. The parser only accepted double quoted arguments which made nested
+quotes difficult.
+
+1. **Parser update**
+   - ``CommandExecutor`` now accepts single- or double-quoted argument values.
+2. **Docs**
+   - README and ``docs/commands.rst`` include guidance on wrapping the ``cmd``
+     value in single quotes when it contains double quotes.
+3. **Tests**
+   - Added unit test covering single-quoted arguments.
+
+> **Acceptance**: ``[[COMMAND: EXEC cmd='echo "hi"']]`` executes successfully.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,3 +82,8 @@
 - README now links to the docs and command table was moved.
 - UI footer includes a link to `/docs`.
 - Sphinx build now runs without warnings and phase 13 is complete.
+
+## Phase 14 - Improved EXEC Quoting
+- Command parser now accepts single-quoted argument values.
+- Documentation includes advice for Windows quoting.
+- Added tests for single-quoted commands.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ python -m laser_lens.cli_main --topic "Your research topic"
 The CLI now interprets command markers and prints their results inline,
 matching the formatting shown in the Streamlit UI.
 
+When passing a command with embedded double quotes to ``EXEC`` use single quotes
+around the entire ``cmd`` value to avoid quoting issues on Windows.
+
 ### Streamlit UI
 
 ```bash

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -21,7 +21,7 @@ The following commands are available to the agent:
    * - DELETE_FILE
      - Delete a file from outputs/.
    * - EXEC
-     - Execute a sandboxed shell command. Use ``dry_run=true`` to preview.
+     - Execute a sandboxed shell command. Use ``dry_run=true`` to preview. On Windows wrap the entire command in single quotes if it contains double quotes.
    * - RUN_PYTHON
      - Run Python code inside the sandbox.
    * - WORD_COUNT

--- a/laser_lens/command_executor.py
+++ b/laser_lens/command_executor.py
@@ -67,8 +67,13 @@ class CommandExecutor:
         Raises ValueError if format is invalid.
         """
         args: Dict[str, Any] = {}
-        pair_pattern = re.compile(r'(\w+)\s*=\s*"(.*?)"', re.DOTALL)
-        for key, val in pair_pattern.findall(raw):
+        pair_pattern = re.compile(
+            r"(\w+)\s*=\s*(\"[^\"]*\"|'[^']*')",
+            re.DOTALL,
+        )
+        for match in pair_pattern.finditer(raw):
+            key = match.group(1)
+            val = match.group(2)[1:-1]  # strip quotes
             args[key] = val
         cleaned_raw = raw.replace("\n", " ").strip()
         leftover = pair_pattern.sub("", cleaned_raw).strip()

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -51,3 +51,16 @@ def test_alias_ls(monkeypatch, tmp_path):
     cmd, output = results[0]
     assert cmd == 'LS'
     assert 'sample.txt' in output
+
+
+def test_single_quote_args(tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    ce = CommandExecutor(logger)
+
+    def foo(args):
+        return args.get("val")
+
+    ce.register_command("FOO", foo)
+    results = ce.parse_and_execute("[[COMMAND: FOO val='bar baz']]")
+    assert results == [("FOO", "bar baz")]


### PR DESCRIPTION
## Summary
- allow command args to be single or double quoted
- document quoting guidance in README and docs
- add test for single-quoted command arguments
- record new Phase 14 in AGENTS roadmap and CHANGELOG

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bad066344832287b6befd935d85a9