### PR TITLE
Finalize Phase 14 quoting updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - Agents may propose improvements or modifications to this roadmap and should update the relevant phase descriptions before implementing them.
 - Review `laser_lens/outputs/GEMINIOUTPUT.md` for automated notes from Gemini. Use this file and `laser_lens/outputs/GEMINIINPUT.md` to exchange messages between agents. When new feedback appears, add a phase update here and record the timestamp below.
 
-Last feedback synced: 2025-06-25 07:32 UTC
+Last feedback synced: 2025-06-25 08:10 UTC
 
 ### Phase Status
 
@@ -32,7 +32,7 @@ Last feedback synced: 2025-06-25 07:32 UTC
 | 11 – Extended HELP & Python Sandbox | ✅ Completed |
 | 12 – Resume Rendering Fix | ✅ Completed |
 | 13 – Documentation Overhaul | ✅ Completed |
-| 14 – Improved EXEC Quoting | 🚧 In Progress |
+| 14 – Improved EXEC Quoting | ✅ Completed |
 
 ---
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -17,3 +17,4 @@ This document records notes, lessons learned, and pain points discovered while w
 - Moved Start button into settings form and converted control buttons to icons.
 - Implemented RUN_PYTHON command and expanded HELP output. Updated docs and tests accordingly.
 - Began phase 13 with Sphinx docs and README cleanup.
+\n- Completed Phase 14 by adding single-quote support to EXEC. Updated docs and tests.

--- a/laser_lens/outputs/GEMINIINPUT.md
+++ b/laser_lens/outputs/GEMINIINPUT.md
@@ -1,1 +1,1 @@
-# Codex Places Feedback to User/Gemini for bi-directional communication (DO NOT REMOVE THIS LINE!)
+# Codex Places Feedback to User/Gemini for bi-directional communication (DO NOT REMOVE THIS LINE!)\nPhase 14 quoting fix implemented and documented.


### PR DESCRIPTION
## Summary
- mark Phase 14 complete and sync latest feedback timestamp
- note completion in `JOURNAL.md`
- acknowledge change in `GEMINIINPUT.md`
- test EXEC with single-quoted command through `CommandExecutor`

## Testing
- `ruff check tests/test_exec.py`
- `pytest -q`
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_685bae56b45483228e6078c3de4dd859