### PR TITLE
Phase 15 – pause reason display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - Agents may propose improvements or modifications to this roadmap and should update the relevant phase descriptions before implementing them.
 - Review `laser_lens/outputs/GEMINIOUTPUT.md` for automated notes from Gemini. Use this file and `laser_lens/outputs/GEMINIINPUT.md` to exchange messages between agents. When new feedback appears, add a phase update here and record the timestamp below.
 
-Last feedback synced: 2025-06-25 08:10 UTC
+Last feedback synced: 2025-06-25 10:01 UTC
 
 ### Phase Status
 
@@ -33,6 +33,7 @@ Last feedback synced: 2025-06-25 08:10 UTC
 | 12 – Resume Rendering Fix | ✅ Completed |
 | 13 – Documentation Overhaul | ✅ Completed |
 | 14 – Improved EXEC Quoting | ✅ Completed |
+| 15 – Pause Reason Display | 🔄 In Progress |
 
 ---
 
@@ -303,7 +304,28 @@ quotes difficult.
 3. **Tests**
    - Added unit test covering single-quoted arguments.
 
+
 > **Acceptance**: ``[[COMMAND: EXEC cmd='echo "hi"']]`` executes successfully.
+
+---
+
+## Phase 15 – Pause Reason Display
+
+UI feedback highlighted that reasons provided by ``PAUSE`` or ``CANCEL`` were
+not shown after the agent triggered them. The input box in the sidebar now
+displays the agent's reason in read-only mode and messages sent during a pause
+are preserved for the next loop.
+
+1. **UI Update**
+   - ``ui_main.py`` disables the ``Reason`` field when a pause or cancel reason
+     is present and shows that text.
+2. **Inline Messages**
+   - Added a test ensuring ``ContextManager.add_inline_context`` stores notes
+     for later prompts.
+
+> **Acceptance**: After pausing via ``[[COMMAND: PAUSE reason="break"]]`` the
+> sidebar shows "break" and messages sent while paused appear in the next
+> iteration.
 
 ---
 
@@ -314,9 +336,10 @@ quotes difficult.
 | `handlers.py`         | ✅      | add `EXEC`, alias map     |
 | `recursive_agent.py`  | ✅      | prompt injection, history |
 | `command_executor.py` | 🔄     | case‑insensitive lookup   |
-| `ui_main.py`          | 🎨     | command/output panes      |
+| `ui_main.py`          | 🎨     | pause reason display      |
 | `config.py`           | 🔄     | expose `SAFE_OUTPUT_DIR`  |
 | `tests/test_exec.py`  | ➕      | new tests                 |
+| `tests/test_inline_context.py` | ➕      | pause message test |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,3 +87,7 @@
 - Command parser now accepts single-quoted argument values.
 - Documentation includes advice for Windows quoting.
 - Added tests for single-quoted commands.
+
+## Phase 15 - Pause Reason Display
+- Sidebar now shows the agent-provided reason after PAUSE or CANCEL.
+- Added unit test for inline pause messages.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -18,3 +18,4 @@ This document records notes, lessons learned, and pain points discovered while w
 - Implemented RUN_PYTHON command and expanded HELP output. Updated docs and tests accordingly.
 - Began phase 13 with Sphinx docs and README cleanup.
 \n- Completed Phase 14 by adding single-quote support to EXEC. Updated docs and tests.
+- Started phase 15 to display pause/cancel reasons and ensure inline pause messages reach the agent.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Both the UI and CLI record metadata about each run in `outputs/session.json`.
 Agents can share notes via `outputs/GEMINIOUTPUT.md` and respond using `outputs/GEMINIINPUT.md`.
 
 When paused—via the sidebar button or a `PAUSE` command—the sidebar displays a
-message box so you can send short notes to the agent. The agent must include a
-`reason` whenever issuing `PAUSE` or `CANCEL`.
+message box so you can send short notes to the agent. If the agent pauses or
+cancels itself, its reason appears in the sidebar as a read-only field. The
+agent must include a `reason` whenever issuing `PAUSE` or `CANCEL`.
 
 Large uploads are truncated automatically if they would exceed the agent's
 context window. The first and last portions are kept with a `[truncated]`

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -181,7 +181,18 @@ else:
 
 # Sidebar: Control Buttons
 st.sidebar.markdown("---")
-action_reason = st.sidebar.text_input("Reason", key="action_reason")
+
+paused_reason = agent_state.get_state("paused")
+cancel_reason = agent_state.get_state("cancelled")
+reason_display = paused_reason or cancel_reason or ""
+reason_disabled = bool(reason_display)
+
+if reason_disabled:
+    action_reason = st.sidebar.text_input(
+        "Reason", value=reason_display, key="action_reason", disabled=True
+    )
+else:
+    action_reason = st.sidebar.text_input("Reason", key="action_reason")
 btn_cols = st.sidebar.columns(3)
 with btn_cols[0]:
     pause_btn = st.button("⏸️", help="Pause")
@@ -205,10 +216,8 @@ if send_msg_btn and msg.strip():
     st.sidebar.success("Message queued for next run.")
     st.session_state.reset_pause_msg = True
 
-paused_reason = agent_state.get_state("paused")
 if paused_reason:
     st.sidebar.info(f"Agent paused: {paused_reason}")
-cancel_reason = agent_state.get_state("cancelled")
 if cancel_reason:
     st.sidebar.info(f"Agent cancelled: {cancel_reason}")
 current_loop = agent_state.get_state("current_loop") or 0

--- a/tests/test_inline_context.py
+++ b/tests/test_inline_context.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+from context_manager import ContextManager  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+from config import Config  # noqa: E402
+
+
+def test_inline_message_added(tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    cm = ContextManager(cfg, logger, om)
+
+    cm.add_inline_context("hello world")
+    ctx = cm.get_context()
+    assert "hello world" in ctx


### PR DESCRIPTION
## Summary
- show pause and cancel reasons in sidebar in read-only mode
- add test ensuring inline pause messages persist
- document pause reason display in README
- note new phase in roadmap and changelog

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc8492e808322a6006bc17c92c6b2