### PR TITLE
Fix docs link and add roadmap phases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ Last feedback synced: 2025-06-25 10:01 UTC
 | 13 – Documentation Overhaul | ✅ Completed |
 | 14 – Improved EXEC Quoting | ✅ Completed |
 | 15 – Pause Reason Display | 🔄 In Progress |
+| 16 – Gemini API Key Management | ☐ Proposed |
+| 17 – UI Button Refresh | ☐ Proposed |
 
 ---
 
@@ -326,6 +328,33 @@ are preserved for the next loop.
 > **Acceptance**: After pausing via ``[[COMMAND: PAUSE reason="break"]]`` the
 > sidebar shows "break" and messages sent while paused appear in the next
 > iteration.
+
+---
+
+## Phase 16 – Gemini API Key Management
+
+Enable multiple Gemini API keys so users can switch between them in the UI.
+
+1. **Key Storage**
+   - Store keys with names and optional descriptions in a local file.
+2. **UI Integration**
+   - Dropdown to select a saved key before starting the agent.
+   - "Add Key" button opens a popup to enter key value and description.
+
+> **Acceptance**: UI lists existing keys and the agent uses the selected one.
+
+---
+
+## Phase 17 – UI Button Refresh
+
+Update the sidebar control buttons for better usability.
+
+1. **Layout**
+   - Buttons should be larger square icons placed close together.
+2. **Styling**
+   - Remove borders and excess padding for a cleaner look.
+
+> **Acceptance**: Sidebar buttons appear larger and evenly spaced.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,3 +91,5 @@
 ## Phase 15 - Pause Reason Display
 - Sidebar now shows the agent-provided reason after PAUSE or CANCEL.
 - Added unit test for inline pause messages.
+- Documentation link moved to the sidebar and built HTML added.
+- Added phases 16 and 17 to AGENTS roadmap.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+
+<html lang="en" data-content_root="./">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <title>Laser Lens Documentation &#8212; Laser Lens  documentation</title>
+    <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=5ecbeea2" />
+    <link rel="stylesheet" type="text/css" href="_static/basic.css?v=b08954a9" />
+    <link rel="stylesheet" type="text/css" href="_static/alabaster.css?v=27fed22d" />
+    <script src="_static/documentation_options.js?v=5929fcd5"></script>
+    <script src="_static/doctools.js?v=9bcbadda"></script>
+    <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
+    <link rel="index" title="Index" href="genindex.html" />
+    <link rel="search" title="Search" href="search.html" />
+    <link rel="next" title="Commands" href="commands.html" />
+   
+  <link rel="stylesheet" href="_static/custom.css" type="text/css" />
+  
+
+  
+  
+
+  </head><body>
+  
+
+    <div class="document">
+      <div class="documentwrapper">
+        <div class="bodywrapper">
+          
+
+          <div class="body" role="main">
+            
+  <section id="laser-lens-documentation">
+<h1>Laser Lens Documentation<a class="headerlink" href="#laser-lens-documentation" title="Link to this heading">¶</a></h1>
+<div class="toctree-wrapper compound">
+<p class="caption" role="heading"><span class="caption-text">Contents:</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="commands.html">Commands</a></li>
+<li class="toctree-l1"><a class="reference internal" href="modules.html">API Reference</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="generated/laser_lens.command_executor.html">laser_lens.command_executor</a></li>
+<li class="toctree-l2"><a class="reference internal" href="generated/laser_lens.handlers.html">laser_lens.handlers</a></li>
+<li class="toctree-l2"><a class="reference internal" href="generated/laser_lens.context_manager.html">laser_lens.context_manager</a></li>
+<li class="toctree-l2"><a class="reference internal" href="generated/laser_lens.output_manager.html">laser_lens.output_manager</a></li>
+<li class="toctree-l2"><a class="reference internal" href="generated/laser_lens.command_registration.html">laser_lens.command_registration</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</section>
+
+
+          </div>
+          
+        </div>
+      </div>
+      <div class="sphinxsidebar" role="navigation" aria-label="Main">
+        <div class="sphinxsidebarwrapper">
+<h1 class="logo"><a href="#">Laser Lens</a></h1>
+
+
+
+
+
+
+
+
+
+<search id="searchbox" style="display: none" role="search">
+    <div class="searchformwrapper">
+    <form class="search" action="search.html" method="get">
+      <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search"/>
+      <input type="submit" value="Go" />
+    </form>
+    </div>
+</search>
+<script>document.getElementById('searchbox').style.display = "block"</script><h3>Navigation</h3>
+<p class="caption" role="heading"><span class="caption-text">Contents:</span></p>
+<ul>
+<li class="toctree-l1"><a class="reference internal" href="commands.html">Commands</a></li>
+<li class="toctree-l1"><a class="reference internal" href="modules.html">API Reference</a></li>
+</ul>
+
+<div class="relations">
+<h3>Related Topics</h3>
+<ul>
+  <li><a href="#">Documentation overview</a><ul>
+      <li>Next: <a href="commands.html" title="next chapter">Commands</a></li>
+  </ul></li>
+</ul>
+</div>
+
+
+
+
+
+
+
+
+        </div>
+      </div>
+      <div class="clearer"></div>
+    </div>
+    <div class="footer">
+      &#169;.
+      
+      |
+      Powered by <a href="https://www.sphinx-doc.org/">Sphinx 8.2.3</a>
+      &amp; <a href="https://alabaster.readthedocs.io">Alabaster 1.0.0</a>
+      
+      |
+      <a href="_sources/index.rst.txt"
+          rel="nofollow">Page source</a>
+    </div>
+
+    
+
+    
+  </body>
+</html>

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -277,6 +277,7 @@ if st.session_state.progress_bar is None:
     st.session_state.progress_bar = st.sidebar.progress(0.0)
 if st.session_state.error_container is None:
     st.session_state.error_container = st.empty()
+st.sidebar.markdown("[📖 Documentation](/docs/index.html)")
 
 
 def start_agent() -> bool:
@@ -503,6 +504,3 @@ if resume_btn and st.session_state.agent:
 
 if stop_btn and st.session_state.agent:
     st.session_state.agent.request_cancel(action_reason or "user cancel")
-
-# Documentation Link
-st.markdown("[📖 Documentation](/docs/index.html)")


### PR DESCRIPTION
## Summary
- generate `docs/index.html` so the documentation button works
- move the docs button to the sidebar in the Streamlit UI
- add phases 16 and 17 for API key management and larger buttons
- mention roadmap updates in the changelog

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bccd029d8832299d479b03e4ad961