### PR TITLE
Implement phase 16 - Gemini API key management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ Last feedback synced: 2025-06-25 10:01 UTC
 | 12 – Resume Rendering Fix | ✅ Completed |
 | 13 – Documentation Overhaul | ✅ Completed |
 | 14 – Improved EXEC Quoting | ✅ Completed |
-| 15 – Pause Reason Display | 🔄 In Progress |
-| 16 – Gemini API Key Management | ☐ Proposed |
+| 15 – Pause Reason Display | ✅ Completed |
+| 16 – Gemini API Key Management | ✅ Completed |
 | 17 – UI Button Refresh | ☐ Proposed |
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,3 +93,7 @@
 - Added unit test for inline pause messages.
 - Documentation link moved to the sidebar and built HTML added.
 - Added phases 16 and 17 to AGENTS roadmap.
+
+## Phase 16 - Gemini API Key Management
+- Added persistent key storage in `~/.laser_lens_keys.json`.
+- Sidebar dropdown selects the active key and new keys can be added.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ pip install -r requirements.txt
 cp .env.example .env  # add your API key
 ```
 
+### API Keys
+
+The Streamlit UI can manage multiple Gemini API keys. Saved keys are stored in
+`~/.laser_lens_keys.json`. Use the **Add Key** button in the sidebar to enter a
+new key with an optional description and select it from the dropdown before
+starting the agent.
+
 ### Python Sandbox
 
 To run `RUN_PYTHON` commands create a virtual environment and install

--- a/tests/test_api_keys.py
+++ b/tests/test_api_keys.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+import utils  # noqa: E402
+
+
+def test_save_and_load(tmp_path, monkeypatch):
+    path = tmp_path / "keys.json"
+    monkeypatch.setattr(utils, "KEYS_PATH", str(path))
+    utils.save_api_key("main", "ABC", "desc")
+    keys = utils.load_api_keys()
+    assert keys == [{"name": "main", "key": "ABC", "description": "desc"}]
+    utils.save_api_key("main", "XYZ", "new")
+    keys = utils.load_api_keys()
+    assert keys[0]["key"] == "XYZ"
+    assert keys[0]["description"] == "new"
+
+
+def test_pref_key(tmp_path, monkeypatch):
+    prefs = tmp_path / "prefs.json"
+    monkeypatch.setattr(utils, "PREFS_PATH", str(prefs))
+    utils.save_pref_key("k1")
+    choice = utils.load_pref_key(["k0", "k1"])
+    assert choice == "k1"


### PR DESCRIPTION
## Summary
- complete phase 16 of the roadmap
- store API keys in `~/.laser_lens_keys.json`
- allow selecting and adding keys in the Streamlit UI
- persist last used key in prefs
- document API key management
- mark phase 15 and 16 complete in roadmap
- add tests for key storage helpers

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bcf09ed108322b7b408d06dfff05a