### PR TITLE
Add thinking mode toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,6 @@
 - Manage Keys form supports editing and deleting stored keys.
 - Model list refreshes when a key is applied.
 - Stream shows friendly message when quota limits are hit.
+
+## Unphased - Thinking Mode
+- Optional chat-only prompt toggle in CLI (`--thinking-mode`) and UI checkbox.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -19,3 +19,4 @@ This document records notes, lessons learned, and pain points discovered while w
 - Began phase 13 with Sphinx docs and README cleanup.
 \n- Completed Phase 14 by adding single-quote support to EXEC. Updated docs and tests.
 - Started phase 15 to display pause/cancel reasons and ensure inline pause messages reach the agent.
+- Added a thinking mode toggle to suppress OS instructions in prompts.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ pip install -r requirements.txt
 ```bash
 python -m laser_lens.cli_main --topic "Your research topic"
 ```
+Add `--thinking-mode` to run without OS sandbox instructions.
 The CLI now interprets command markers and prints their results inline,
 matching the formatting shown in the Streamlit UI.
 
@@ -46,6 +47,7 @@ around the entire ``cmd`` value to avoid quoting issues on Windows.
 ```bash
 streamlit run laser_lens/ui_main.py
 ```
+Check the "Thinking Mode" box in the sidebar to use chat-only prompts.
 
 During each loop the UI highlights commands as informational blocks and shows
 their results in separate code sections. The view automatically scrolls to the

--- a/laser_lens/cli_main.py
+++ b/laser_lens/cli_main.py
@@ -87,6 +87,9 @@ def main():
         default=Config().default_rpm,
         help="Requests per minute (rate limiting)."
     )
+    parser.add_argument("--thinking-mode",
+        action="store_true",
+        help="Enable chat-only reasoning mode without OS instructions.")
     parser.add_argument(
         "--resume",
         type=str,
@@ -144,6 +147,7 @@ def main():
             seed=args.seed,
             rpm=args.rpm,
             api_key=os.getenv("GOOGLE_API_KEY"),
+            thinking_mode=args.thinking_mode,
         )
     except Exception as e:
         sys.stderr.write(f"[ERROR] Failed to instantiate agent: {e}\n")

--- a/laser_lens/config.py
+++ b/laser_lens/config.py
@@ -14,6 +14,7 @@ class Config:
     # Recursive parameters
     default_loops: int = 3
     default_prompt_delim: str = "###"  # delimiter for parsing .tmp streams
+    default_thinking_mode: bool = False  # chat-only prompt style
 
     # Context parameters
     max_context_tokens: int = 100000  # maximum tokens/characters allowed in combined context

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -123,6 +123,8 @@ if "seed" not in st.session_state:
     st.session_state.seed = config.default_seed or 0
 if "rpm" not in st.session_state:
     st.session_state.rpm = config.default_rpm
+if "thinking_mode" not in st.session_state:
+    st.session_state.thinking_mode = config.default_thinking_mode
 if "reset_pause_msg" not in st.session_state:
     st.session_state.reset_pause_msg = False
 
@@ -181,6 +183,11 @@ with st.sidebar.form("agent_settings"):
     rpm_in = st.number_input(
         "Requests/minute", min_value=1, max_value=100, value=st.session_state.rpm, key="rpm_in"
     )
+    thinking_in = st.checkbox(
+        "Thinking Mode",
+        value=st.session_state.thinking_mode,
+        key="thinking_in",
+    )
     btn_cols = st.columns(2)
     with btn_cols[0]:
         apply_btn = st.form_submit_button("Apply")
@@ -232,6 +239,7 @@ if apply_btn or start_btn:
     st.session_state.temperature = temp_in
     st.session_state.seed = seed_in
     st.session_state.rpm = rpm_in
+    st.session_state.thinking_mode = thinking_in
     new_models = get_available_models(selected_api_key_value())
     st.session_state.models_available = new_models
     if st.session_state.model_name not in new_models:
@@ -395,6 +403,7 @@ def start_agent() -> bool:
             seed=st.session_state.seed or None,
             rpm=st.session_state.rpm,
             api_key=api_key_val,
+            thinking_mode=st.session_state.thinking_mode,
         )
         return True
     except Exception as e:

--- a/tests/test_thinking_mode.py
+++ b/tests/test_thinking_mode.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "laser_lens"))
+sys.path.insert(0, ROOT)
+
+# Stub google modules
+google = types.ModuleType("google")
+generativeai = types.ModuleType("generativeai")
+class DummyModel:
+    def __init__(self, *a, **k):
+        pass
+
+generativeai.GenerativeModel = DummyModel
+google.generativeai = generativeai
+sys.modules.setdefault("google", google)
+sys.modules.setdefault("google.generativeai", generativeai)
+
+from recursive_agent import RecursiveAgent  # noqa: E402
+from command_executor import CommandExecutor  # noqa: E402
+from context_manager import ContextManager  # noqa: E402
+from output_manager import OutputManager  # noqa: E402
+from agent_state import AgentState  # noqa: E402
+from error_logger import ErrorLogger  # noqa: E402
+from config import Config  # noqa: E402
+
+
+def test_thinking_mode_prompt(tmp_path):
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    cm = ContextManager(cfg, logger, om)
+    ce = CommandExecutor(logger)
+    state = AgentState(cfg, logger)
+
+    agent = RecursiveAgent(
+        config=cfg,
+        error_logger=logger,
+        command_executor=ce,
+        context_manager=cm,
+        output_manager=om,
+        agent_state=state,
+        model_name="dummy",
+        topic="t",
+        loops=1,
+        temperature=0.0,
+        seed=None,
+        rpm=10,
+        api_key="x",
+        thinking_mode=True,
+    )
+
+    prompt = agent._build_prompt("")
+    assert "sandbox" not in prompt
+    assert "HELP" not in prompt


### PR DESCRIPTION
## Summary
- support a chat-only thinking mode without OS sandbox hints
- add `--thinking-mode` option to CLI and checkbox in the UI
- document the new feature and record it in the changelog
- unit test for prompt behaviour in thinking mode

## Testing
- `ruff check laser_lens tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0abd577c83229ee05c2e4a9c83f4