### PR TITLE
Phase 17 - UI button refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - Agents may propose improvements or modifications to this roadmap and should update the relevant phase descriptions before implementing them.
 - Review `laser_lens/outputs/GEMINIOUTPUT.md` for automated notes from Gemini. Use this file and `laser_lens/outputs/GEMINIINPUT.md` to exchange messages between agents. When new feedback appears, add a phase update here and record the timestamp below.
 
-Last feedback synced: 2025-06-25 10:01 UTC
+Last feedback synced: 2025-06-25 16:43 UTC
 
 ### Phase Status
 
@@ -35,7 +35,8 @@ Last feedback synced: 2025-06-25 10:01 UTC
 | 14 – Improved EXEC Quoting | ✅ Completed |
 | 15 – Pause Reason Display | ✅ Completed |
 | 16 – Gemini API Key Management | ✅ Completed |
-| 17 – UI Button Refresh | ☐ Proposed |
+| 17 – UI Button Refresh | ✅ Completed |
+| 18 – Robust WRITE_FILE Parsing | ☐ Proposed |
 
 ---
 
@@ -355,6 +356,18 @@ Update the sidebar control buttons for better usability.
    - Remove borders and excess padding for a cleaner look.
 
 > **Acceptance**: Sidebar buttons appear larger and evenly spaced.
+
+---
+
+## Phase 18 – Robust WRITE_FILE Parsing
+
+Feedback indicates multi-line strings sometimes fail to save correctly when
+passed to `WRITE_FILE`. Improve argument parsing so any text is preserved
+exactly, regardless of newlines or quoting. Consider supporting a
+`base64`-encoded mode if standard quoting remains unreliable.
+
+> **Acceptance**: Multi-line content round-trips without corruption and
+  relative paths no longer cause errors.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,5 +101,9 @@
 - Model list refreshes when a key is applied.
 - Stream shows friendly message when quota limits are hit.
 
+## Phase 17 - UI Button Refresh
+- Sidebar control buttons are now larger square icons without borders.
+- README updated with note about button styling.
+
 ## Unphased - Thinking Mode
 - Optional chat-only prompt toggle in CLI (`--thinking-mode`) and UI checkbox.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -20,3 +20,4 @@ This document records notes, lessons learned, and pain points discovered while w
 \n- Completed Phase 14 by adding single-quote support to EXEC. Updated docs and tests.
 - Started phase 15 to display pause/cancel reasons and ensure inline pause messages reach the agent.
 - Added a thinking mode toggle to suppress OS instructions in prompts.
+- Styled sidebar control buttons with larger square icons during phase 17.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ from a pause the page jumps back to the latest output instead of the top. The si
 displays the current agent status. The Start button now lives inside the
 settings form so any changes are applied automatically, while the
 Pause/Resume/Stop controls appear in a single row using icon-only buttons.
+The icons are now larger square buttons with minimal padding for easier access.
 Both the UI and CLI record metadata about each run in `outputs/session.json`.
 Agents can share notes via `outputs/GEMINIOUTPUT.md` and respond using `outputs/GEMINIINPUT.md`.
 

--- a/laser_lens/ui_main.py
+++ b/laser_lens/ui_main.py
@@ -269,13 +269,27 @@ if reason_disabled:
     )
 else:
     action_reason = st.sidebar.text_input("Reason", key="action_reason")
-btn_cols = st.sidebar.columns(3)
+btn_cols = st.sidebar.columns(3, gap="small")
 with btn_cols[0]:
-    pause_btn = st.button("⏸️", help="Pause")
+    pause_btn = st.button("⏸️", help="Pause", use_container_width=True)
 with btn_cols[1]:
-    resume_btn = st.button("▶️", help="Resume")
+    resume_btn = st.button("▶️", help="Resume", use_container_width=True)
 with btn_cols[2]:
-    stop_btn = st.button("⏹️", help="Stop")
+    stop_btn = st.button("⏹️", help="Stop", use_container_width=True)
+st.sidebar.markdown(
+    """
+    <style>
+    div[data-testid="column"] > div.stButton button {
+        width: 3em;
+        height: 3em;
+        padding: 0;
+        margin: 0 0.25em 0.25em 0;
+        border: none;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 # Message box (enabled when paused)
 if st.session_state.reset_pause_msg:


### PR DESCRIPTION
## Summary
- style sidebar control buttons as larger square icons
- document new look in README
- log the change in JOURNAL and CHANGELOG
- mark Phase 17 complete and add Phase 18 proposal

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c269c82c08322a442b722aa0f132c