### PR TITLE
Implement phase 18 base64 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - Agents may propose improvements or modifications to this roadmap and should update the relevant phase descriptions before implementing them.
 - Review `laser_lens/outputs/GEMINIOUTPUT.md` for automated notes from Gemini. Use this file and `laser_lens/outputs/GEMINIINPUT.md` to exchange messages between agents. When new feedback appears, add a phase update here and record the timestamp below.
 
-Last feedback synced: 2025-06-25 16:43 UTC
+Last feedback synced: 2025-06-25 17:14 UTC
 
 ### Phase Status
 
@@ -36,7 +36,8 @@ Last feedback synced: 2025-06-25 16:43 UTC
 | 15 – Pause Reason Display | ✅ Completed |
 | 16 – Gemini API Key Management | ✅ Completed |
 | 17 – UI Button Refresh | ✅ Completed |
-| 18 – Robust WRITE_FILE Parsing | ☐ Proposed |
+| 18 – Robust WRITE_FILE Parsing | ✅ Completed |
+| 19 – Command Robustness | ☐ Proposed |
 
 ---
 
@@ -368,6 +369,25 @@ exactly, regardless of newlines or quoting. Consider supporting a
 
 > **Acceptance**: Multi-line content round-trips without corruption and
   relative paths no longer cause errors.
+
+---
+
+## Phase 19 – Command Robustness
+
+Incorporate feedback from recent Gemini testing to harden command handling and
+extend functionality.
+
+1. **RUN_PYTHON Multi-line Support** – allow blocks of Python code or provide a
+   base64-encoded option similar to ``WRITE_FILE``.
+2. **Unified Argument Parsing** – improve error messages and parsing logic for
+   all commands to reduce quoting mistakes.
+3. **EXEC Coverage** – test commonly used shell utilities and clearly document
+   any limitations.
+4. **Persistent Workspace** – verify files remain accessible across sessions and
+   highlight the behaviour in docs.
+
+> **Acceptance**: Enhanced error messages guide the user and complex command
+> inputs execute reliably.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,11 @@
 - Sidebar control buttons are now larger square icons without borders.
 - README updated with note about button styling.
 
+## Phase 18 - Robust WRITE_FILE Parsing
+- WRITE_FILE now accepts ``encoding="base64"`` and decodes content before saving.
+- Added unit test for base64 writing.
+- Documented the new option in README and command reference.
+
 ## Unphased - Thinking Mode
 - Optional chat-only prompt toggle in CLI (`--thinking-mode`) and UI checkbox.
 - Fixed clipboard copy button in streaming pane using HTML components.

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -22,3 +22,4 @@ This document records notes, lessons learned, and pain points discovered while w
 - Added a thinking mode toggle to suppress OS instructions in prompts.
 - Styled sidebar control buttons with larger square icons during phase 17.
 - Fixed broken copy button in stream output by using components.html for script.
+- Implemented base64 support for WRITE_FILE and added tests.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ matching the formatting shown in the Streamlit UI.
 
 When passing a command with embedded double quotes to ``EXEC`` use single quotes
 around the entire ``cmd`` value to avoid quoting issues on Windows.
+For multi-line data use ``encoding="base64"`` with ``WRITE_FILE`` and provide
+base64 encoded content.
 
 ### Streamlit UI
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -9,7 +9,8 @@ The following commands are available to the agent:
    * - Command
      - Description
    * - WRITE_FILE
-     - Save content to the outputs directory. Use ``dry_run=true`` to preview.
+     - Save content to the outputs directory. Use ``dry_run=true`` to preview or
+       ``encoding="base64"`` for base64 data.
    * - APPEND_FILE
      - Append text to an existing file.
    * - READ_FILE

--- a/laser_lens/handlers.py
+++ b/laser_lens/handlers.py
@@ -37,16 +37,35 @@ COMMAND_HELP: Dict[str, tuple[str, str]] = {
 
 
 def WRITE_FILE(args: Dict[str, Any]) -> str:
+    """Write text to a file in the outputs directory.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to write within ``outputs/``.
+    content : str
+        Text to save. If ``encoding`` is ``base64`` the value will be decoded
+        before saving.
+    dry_run : str, optional
+        If ``"true"`` no file is written and a preview message is returned.
+    encoding : str, optional
+        If set to ``"base64"`` content is treated as base64 encoded UTF-8.
     """
-    Usage in LLM output:
-        [[COMMAND: WRITE_FILE filename="notes.md" content="Hello world!"]]
-    Writes the given content to ./outputs/filename, returns a confirmation message.
-    """
+
     fname = args.get("filename")
     content = args.get("content", "")
+    encoding = str(args.get("encoding", "")).lower()
     dry = str(args.get("dry_run", "false")).lower() == "true"
     if not fname:
         return "ERROR: Missing required argument 'filename'."
+
+    if encoding == "base64":
+        try:
+            import base64
+
+            content = base64.b64decode(content).decode("utf-8")
+        except Exception as e:  # pragma: no cover - unexpected decode errors
+            return f"ERROR: Could not decode base64 content: {e}"
 
     if dry:
         safe = _output_mgr.sanitize_filename(fname)

--- a/tests/test_append_file.py
+++ b/tests/test_append_file.py
@@ -60,3 +60,20 @@ def test_read_file_truncation(tmp_path, monkeypatch):
     result = READ_FILE({"filename": "big.txt"})
     assert result.startswith("WARNING:")
     assert "CONTENT_START" in result
+
+
+def test_write_file_base64(tmp_path, monkeypatch):
+    """WRITE_FILE should decode base64 content when encoding=base64."""
+    import base64
+
+    cfg = Config(safe_output_dir=str(tmp_path))
+    logger = ErrorLogger(cfg)
+    om = OutputManager(cfg, logger)
+    monkeypatch.setattr('handlers._cfg', cfg)
+    monkeypatch.setattr('handlers._output_mgr', om)
+
+    text = "hello\nworld"
+    b64 = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    WRITE_FILE({"filename": "b.txt", "content": b64, "encoding": "base64"})
+    with open(os.path.join(tmp_path, "b.txt"), "r", encoding="utf-8") as f:
+        assert f.read() == text


### PR DESCRIPTION
## Summary
- implement `encoding="base64"` for WRITE_FILE
- document new option in README and command docs
- add base64 round‑trip test
- record progress and open new phase for command robustness

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c2e211ac883229d2bc9da0d2e1fa7